### PR TITLE
[FEAT] Add AHeaderAnalyzer and ARequestParser classes

### DIFF
--- a/include/AHeaderAnalyzer.hpp
+++ b/include/AHeaderAnalyzer.hpp
@@ -1,0 +1,113 @@
+#pragma once
+#include <cstddef>
+#include <string>
+
+namespace webserver
+{
+
+/**
+ * @brief Content types for the HTTP headers.
+ *
+ * Defines the different content types for the HTTP headers.
+ */
+enum ContentType
+{
+    TEXT,
+    IMAGE,
+    AUDIO,
+    VIDEO,
+    APPLICATION,
+    MULTIPART,
+    MESSAGE,
+    MODEL,
+    OTHER
+};
+
+/**
+ * @brief Connection types for the HTTP headers.
+ *
+ * Defines the different connection types for the HTTP headers.
+ */
+enum Connection
+{
+    KEEP_ALIVE,
+    CLOSE
+};
+
+/**
+ * @brief Encoding types for the HTTP headers.
+ *
+ * Defines the different encoding types for the HTTP headers.
+ */
+enum Encoding
+{
+    GZIP,
+    DEFLATE,
+    BR,
+    IDENTITY,
+    CHUNKED,
+    COMPRESS
+};
+
+/**
+ * @brief HTTP methods for the HTTP headers.
+ *
+ * Defines the different HTTP methods for the HTTP headers.
+ */
+enum Method
+{
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE
+};
+
+/**
+ * @brief HTTP versions for the HTTP headers.
+ *
+ * Defines the different HTTP versions for the HTTP headers.
+ */
+enum Version
+{
+    HTTP_1_0,
+    HTTP_1_1,
+    HTTP_2_0,
+    HTTP_3_0
+};
+
+/**
+ * @brief Abstract class for analyzing HTTP headers and extracting information.
+ *
+ * The AHedaerAnalyzer class provides an interface for analyzing HTTP headers.
+ * It defines the analyze function that must be implemented by derived classes.
+ */
+class AHedaerAnalyzer
+{
+  public:
+    virtual ~AHedaerAnalyzer()
+    {
+    }
+
+    /**
+     * @brief Analyze the HTTP headers.
+     *
+     * This function analyzes the HTTP headers and extracts information such as
+     * the version, method, host, content length, content type, connection, encoding,
+     * cookie, and cache control.
+     */
+    virtual void analyze(void) = 0;
+
+  protected:
+    Version _version;
+    Method _method;
+    std::string _host;
+    size_t _content_length;
+    ContentType _content_type;
+    Connection _connection;
+    Encoding _encoding;
+    std::string _cookie;
+    std::string _cache_control;
+};
+
+} // namespace webserver

--- a/include/ARequestParser.hpp
+++ b/include/ARequestParser.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include <string>
+
+namespace webserver
+{
+
+/**
+ * @brief Parser states for the request parser.
+ *
+ * Defines the different states the request parser can be in.
+ */
+enum ParserState
+{
+    REQUEST_LINE,
+    HEADER,
+    BODY,
+    FINISHED
+};
+
+/**
+ * @brief Abstract class for parsing HTTP requests.
+  *
+  * The ARequestParser class provides an interface for parsing HTTP requests.
+  * It defines the parse function that must be implemented by derived classes.
+  * Use state machine to parse the raw request.
+  */
+class ARequestParser
+{
+  public:
+    /**
+     * @brief Destroy the ARequestParser object.
+     */
+    virtual ~ARequestParser()
+    {
+    }
+
+    /**
+     * @brief Parse the raw request.
+     *
+     * This function parses the raw request and extracts the request line,
+     * header, and body.
+     *
+     * @param raw_request The raw request to parse.
+     */
+    virtual void parse(const std::string& raw_request) = 0;
+    std::string request_line() const;
+    std::string header() const;
+    std::string body() const;
+
+  protected:
+    ParserState _state;
+    std::string _request_line;
+    std::string _header;
+    std::string _body;
+};
+
+} // namespace webserver


### PR DESCRIPTION
* Define the abstract classes for the header analyzer and request parser.
* Each version of HTTP need to inherit the abstract classes and implement the analyze and parse functions.