### PR TITLE
[FEAT] Add impl. of keep alive correctly

### DIFF
--- a/include/kernel/kernel_utils.hpp
+++ b/include/kernel/kernel_utils.hpp
@@ -1,0 +1,10 @@
+#include <sys/socket.h>
+#include <iostream>
+#include <stdint.h>
+#include <sys/epoll.h>
+#include "defines.hpp"
+
+namespace webkernel
+{
+    std::string explain_epoll_event(uint32_t events);
+} // namespace webkernel

--- a/include/shell/HeaderAnalyzer.hpp
+++ b/include/shell/HeaderAnalyzer.hpp
@@ -26,7 +26,7 @@ class HeaderAnalyzer
     std::string accept() const;
     std::string accept_encoding() const;
     std::string connection() const;
-    ConnectionType content_type() const;
+    ConnectionType connection_type() const;
     std::string content_length() const;
 
   private:

--- a/source/kernel/Acceptor.cpp
+++ b/source/kernel/Acceptor.cpp
@@ -16,8 +16,6 @@ Acceptor::Acceptor() : _reactor(NULL), _config(NULL), _server_id(-1)
 Acceptor::Acceptor(Reactor* reactor, webconfig::Config* config)
     : _reactor(reactor), _config(config), _server_id(-1)
 {
-    weblog::logger.log(weblog::DEBUG, "Acceptor created with server_id: " +
-                                          utils::to_string(_server_id));
 }
 
 Acceptor::Acceptor(const Acceptor& other)
@@ -70,6 +68,8 @@ void Acceptor::handle_event(int fd, uint32_t events)
 
 void Acceptor::setup_server_id(int server_id)
 {
+    weblog::logger.log(weblog::DEBUG, "Acceptor setup with server_id: " +
+                                          utils::to_string(server_id));
     _server_id = server_id;
 }
 

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -2,6 +2,7 @@
 #include "defines.hpp"
 #include "utils/Logger.hpp"
 #include "utils/utils.hpp"
+#include "kernel_utils.hpp"
 #include <ctime>
 
 namespace webkernel
@@ -50,11 +51,15 @@ ConnectionHandler::~ConnectionHandler()
     weblog::logger.log(weblog::DEBUG,
                        "ConnectionHandler destroyed with server_id: " +
                            utils::to_string(_server_id));
-    _handle_close(_conn_fd, weblog::INFO, "Connection closed by server");
+    // TODO: Check the conn_fd is closed by the reactor
+    // _handle_close(_conn_fd, weblog::INFO, "Connection closed by server");
 }
 
 void ConnectionHandler::handle_event(int fd, uint32_t events)
 {
+    weblog::logger.log(weblog::DEBUG,
+                       "ConnectionHandler::handle_event() on fd: " +
+                           utils::to_string(fd) + " with events: " + explain_epoll_event(events));
     if (events & EPOLLIN)
         _handle_read(fd);
     else if (events & EPOLLOUT)
@@ -85,7 +90,7 @@ void ConnectionHandler::_handle_read(int fd)
 {
     char buffer[CHUNKED_SIZE];
 
-    while (true)
+    while (_keep_alive())
     {
         ssize_t bytes_read = read(fd, buffer, CHUNKED_SIZE);
 
@@ -107,8 +112,8 @@ void ConnectionHandler::_handle_read(int fd)
         }
         else if (bytes_read == 0)
         {
-            _handle_close(fd, weblog::INFO, "Connection closed by client");
-            return;
+            weblog::logger.log(weblog::INFO, "Read 0 bytes, waiting for more data");
+            break;
         }
         else
         {
@@ -123,8 +128,7 @@ void ConnectionHandler::_handle_read(int fd)
             }
         }
     }
-    if (!_keep_alive())
-        _handle_close(fd, weblog::INFO, "Keep-alive timeout or close request");
+    _handle_close(fd, weblog::INFO, "Keep-alive timeout or close request");
 }
 
 void ConnectionHandler::_handle_write(int fd)
@@ -135,8 +139,7 @@ void ConnectionHandler::_handle_write(int fd)
 void ConnectionHandler::_handle_close(int fd, weblog::LogLevel level,
                                       std::string message)
 {
-    weblog::logger.log(level, message);
-    utils::safe_close(fd);
+    weblog::logger.log(level, message + " on fd: " + utils::to_string(fd));
     _reactor->remove_handler(fd);
 }
 

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -146,7 +146,7 @@ bool ConnectionHandler::_keep_alive(void)
     double elapsed = difftime(now, _start_time);
 
     weblog::logger.log(weblog::DEBUG, "Elapsed time: " + utils::to_string(elapsed));
-    if (_request_parser.header_analyzer().content_type() == webshell::CLOSE)
+    if (_request_parser.header_analyzer().connection_type() == webshell::CLOSE)
         return (false);
     else if (elapsed > _server_config.keep_alive_timeout())
         return (false);

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -90,7 +90,7 @@ void ConnectionHandler::_handle_read(int fd)
 {
     char buffer[CHUNKED_SIZE];
 
-    while (_keep_alive())
+    while (true)
     {
         ssize_t bytes_read = read(fd, buffer, CHUNKED_SIZE);
 
@@ -127,6 +127,8 @@ void ConnectionHandler::_handle_read(int fd)
                 return;
             }
         }
+        if (!_keep_alive())
+            break;
     }
     _handle_close(fd, weblog::INFO, "Keep-alive timeout or close request");
 }

--- a/source/shell/HeaderAnalyzer.cpp
+++ b/source/shell/HeaderAnalyzer.cpp
@@ -3,7 +3,7 @@
 namespace webshell
 {
 
-HeaderAnalyzer::HeaderAnalyzer()
+HeaderAnalyzer::HeaderAnalyzer() : _connection_type(KEEP_ALIVE)
 {
 }
 
@@ -77,7 +77,7 @@ std::string HeaderAnalyzer::connection() const
     return (_connection);
 }
 
-ConnectionType HeaderAnalyzer::content_type() const
+ConnectionType HeaderAnalyzer::connection_type() const
 {
     return (_connection_type);
 }

--- a/source/utils/kernel_utils.cpp
+++ b/source/utils/kernel_utils.cpp
@@ -1,0 +1,26 @@
+#include "kernel_utils.hpp"
+
+namespace webkernel
+{
+    std::string explain_epoll_event(uint32_t events)
+    {
+        std::string explanation;
+
+        if (events & EPOLLIN)
+            explanation += "EPOLLIN ";
+        if (events & EPOLLOUT)
+            explanation += "EPOLLOUT ";
+        if (events & EPOLLRDHUP)
+            explanation += "EPOLLRDHUP ";
+        if (events & EPOLLERR)
+            explanation += "EPOLLERR ";
+        if (events & EPOLLHUP)
+            explanation += "EPOLLHUP ";
+        if (events & EPOLLET)
+            explanation += "EPOLLET ";
+        if (events & EPOLLONESHOT)
+            explanation += "EPOLLONESHOT ";
+
+        return (explanation);
+    }
+} // namespace webkernel


### PR DESCRIPTION
Logger created: console mode
Log level set to: DEBUG
2024-09-02 22:38:39 [DEBUG] Global scope:                                                                                       
2024-09-02 22:38:39 [DEBUG]     worker_processes: 1                                                                                
2024-09-02 22:38:39 [DEBUG]     worker_connections: 1024                                                                           
2024-09-02 22:38:39 [DEBUG] HTTP scope:                                                                                         
2024-09-02 22:38:39 [DEBUG]     client_max_body_size: 1048576                                                                      
2024-09-02 22:38:39 [DEBUG]     default_type: text/html                                                                            
2024-09-02 22:38:39 [DEBUG]     error_page:                                                                                        
2024-09-02 22:38:39 [DEBUG]             404 /404.html                                                                                     
2024-09-02 22:38:39 [DEBUG] Server block [0]:                                                                                   
2024-09-02 22:38:39 [DEBUG] Server block:                                                                                       
2024-09-02 22:38:39 [DEBUG]     Server name: example1.com                                                                          
2024-09-02 22:38:39 [DEBUG]     Listen: 127.0.0.1:8888                                                                             
2024-09-02 22:38:39 [DEBUG]     Error log: logs/error.log error                                                                    
2024-09-02 22:38:39 [DEBUG]     Error log: log/error.log error                                                                     
2024-09-02 22:38:39 [DEBUG]     Keepalive timeout: 65                                                                              
2024-09-02 22:38:39 [DEBUG] Location block [0]:                                                                                 
2024-09-02 22:38:39 [DEBUG]     route: /                                                                                           
2024-09-02 22:38:39 [DEBUG]     limit_except:                                                                                      
2024-09-02 22:38:39 [DEBUG]             GET                                                                                               
2024-09-02 22:38:39 [DEBUG]             POST                                                                                              
2024-09-02 22:38:39 [DEBUG]     root: /var/www/html                                                                                
2024-09-02 22:38:39 [DEBUG]     index: default.html                                                                                
2024-09-02 22:38:39 [DEBUG]     autoindex: 0                                                                                       
2024-09-02 22:38:39 [DEBUG]     cgi_extension:                                                                                     
2024-09-02 22:38:39 [DEBUG]     cgi_path:                                                                                          
2024-09-02 22:38:39 [DEBUG]     enable_upload: 0                                                                                   
2024-09-02 22:38:39 [DEBUG]     upload_path:                                                                                       
2024-09-02 22:38:39 [INFO] Creating single reactor and single worker structure                                                 
2024-09-02 22:38:39 [DEBUG] Reactor::Reactor(ReactorType type)                                                                  
2024-09-02 22:38:39 [DEBUG] Created epoll fd: 5                                                                                 
2024-09-02 22:38:39 [INFO] Listening on 127.0.0.1:8888                                                                         
2024-09-02 22:38:39 [DEBUG] Acceptor setup with server_id: 0                                                                    
2024-09-02 22:38:39 [DEBUG] Registering handler and set to non-blocking with fd: 6                                              
2024-09-02 22:38:39 [INFO] Registered acceptor with fd: 6                                                                      
2024-09-02 22:38:39 [DEBUG] Kernel::run()                                                                                       
2024-09-02 22:38:39 [INFO] Reactor is waiting for epoll events                                                                 
2024-09-02 22:38:53 [DEBUG] Reactor received 1 events                                                                           
`2024-09-02 22:38:53 [INFO] Accepted connection on fd: 7`                                                                        
2024-09-02 22:38:53 [DEBUG] ConnectionHandler created with server_id: 0                                                         
2024-09-02 22:38:53 [DEBUG] Registering handler and set to non-blocking with fd: 7                                              
2024-09-02 22:38:53 [DEBUG] Registered connection handler with fd: 7                                                            
2024-09-02 22:38:53 [INFO] Reactor is waiting for epoll events                                                                 
2024-09-02 22:38:53 [DEBUG] Reactor received 1 events                                                                           
2024-09-02 22:38:53 [DEBUG] ConnectionHandler::handle_event() on fd: 7 with events: EPOLLIN                                     
2024-09-02 22:38:53 [DEBUG] Elapsed time: 0                                                                                     
2024-09-02 22:38:53 [DEBUG] Read 732 bytes from fd: 7                                                                           
2024-09-02 22:38:53 [DEBUG] Buffer: 
GET / HTTP/1.1
Host: 127.0.0.1:8888
Connection: keep-alive
Cache-Control: max-age=0
sec-ch-ua: "Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "macOS"
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Sec-Fetch-Site: cross-site
Sec-Fetch-Mode: navigate
Sec-Fetch-User: ?1
Sec-Fetch-Dest: document
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-CN;q=0.6

��
2024-09-02 22:38:53 [INFO] Request is complete                                                                                 
2024-09-02 22:38:53 [DEBUG] Processing request                                                                                  
2024-09-02 22:38:53 [DEBUG] Responding to request                                                                               
`2024-09-02 22:38:53 [INFO] Keep-alive timeout or close request on fd: 7`                                                        
2024-09-02 22:38:53 [DEBUG] Removed handler with fd: 7                                                                          
2024-09-02 22:38:53 [INFO] Reactor is waiting for epoll events                                                                 
2024-09-02 22:38:54 [DEBUG] Reactor received 1 events                                                                           
`2024-09-02 22:38:54 [INFO] Accepted connection on fd: 7`                                                                        
2024-09-02 22:38:54 [DEBUG] ConnectionHandler created with server_id: 0                                                         
2024-09-02 22:38:54 [DEBUG] Registering handler and set to non-blocking with fd: 7                                              
2024-09-02 22:38:54 [DEBUG] Registered connection handler with fd: 7                                                            
2024-09-02 22:38:54 [INFO] Reactor is waiting for epoll events                                                                 
2024-09-02 22:38:54 [DEBUG] Reactor received 1 events                                                                           
2024-09-02 22:38:54 [DEBUG] ConnectionHandler::handle_event() on fd: 7 with events: EPOLLIN                                     
2024-09-02 22:38:54 [DEBUG] Elapsed time: 0                                                                                     
2024-09-02 22:38:54 [DEBUG] Read 626 bytes from fd: 7                                                                           
2024-09-02 22:38:54 [DEBUG] Buffer: 
GET /favicon.ico HTTP/1.1
Host: 127.0.0.1:8888
Connection: keep-alive
sec-ch-ua: "Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"
sec-ch-ua-mobile: ?0
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
sec-ch-ua-platform: "macOS"
Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8
Sec-Fetch-Site: same-origin
Sec-Fetch-Mode: no-cors
Sec-Fetch-Dest: image
Referer: http://127.0.0.1:8888/
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: zh-TW,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-CN;q=0.6


2024-09-02 22:38:54 [INFO] Request is complete                                                                                 
2024-09-02 22:38:54 [DEBUG] Processing request                                                                                  
2024-09-02 22:38:54 [DEBUG] Responding to request                                                                               
2024-09-02 22:38:54 [INFO] Keep-alive timeout or close request on fd: 7                                                        
2024-09-02 22:38:54 [DEBUG] Removed handler with fd: 7                                                                          
2024-09-02 22:38:54 [INFO] Reactor is waiting for epoll events

--------
This is really interested function, check the logger with code will be more easier to understand.
Notice the logging info which I highlight in grey color. 
1. When the client tries to send requests then the connection with fd(7) be created 
2. Then the timeout happened, after 5sec in this example, the handler be removed and close fd(7)
3. When a new request coming, the connection will be re-build and with fd(7) again