### PR TITLE
[FEAT] Add prototype of decoder headers

### DIFF
--- a/include/kernel/ChunkedDecoder.hpp
+++ b/include/kernel/ChunkedDecoder.hpp
@@ -12,9 +12,73 @@ class ChunkedDecoder : public IDecoder
     ChunkedDecoder& operator=(const ChunkedDecoder& other);
     ~ChunkedDecoder();
 
-    std::string decode(std::istream& is);
+    std::string decode(std::istream& is)
+    {
+      std::ostringstream decoded_data;
+      std::string chunk;
+
+      while (!(chunk = _decode_chunk(is)).empty())
+        decoded_data << chunk;
+      return (decoded_data.str());
+    }
 
   private:
-    int _hex_to_int(char c);
-    std::string _decode_chunk(std::istream& is);
+    std::string _decode_chunk(std::istream& is)
+    {
+      std::string hex_length;
+      std::getline(is, hex_length, '\r');
+      is.ignore(1);
+
+      std::stringstream ss(hex_length);
+      int chunk_size;
+      ss >> std::hex >> chunk_size;
+
+      if (chunk_size == 0)
+      {
+        is.ignore(1);
+        return "";
+      }
+
+      std::string chunk_data(chunk_size, 0);
+      is.read(&chunk_data[0], chunk_size);
+      is.ignore(2);
+
+      return (chunk_data);
+    }
 };
+
+/*
+// usage example
+
+ssize_t bytes_read = read(fd, buffer, CHUNKED_SIZE);
+if (bytes_read > 0)
+{
+  if (_request_parser.header_analyzer().transfer_encoding() == CHUNKED && _request_parser.is_complete())
+  {
+    try
+    {
+      std::string decoded_body;
+
+      if (_request_parser.partial_body().empty())
+        decoded_body = decoder.decode(std::istringstream(std::string(buffer, bytes_read)));
+      else
+      {
+        decoded_body = decoder.decode(std::istringstream(_request_parser.partial_body() + std::string(buffer, bytes_read)));
+        _request_parser.clean_partial_body();
+      }
+      if (!decoded_body.empty())
+      {
+        _process_request(decoded_body);
+        ...
+      }
+    }
+    catch (const std::exception& e)
+    {
+      _handle_close(fd, weblog::ERROR, "Error while decoding chunked data: " + std::string(e.what()));
+      return;
+    }
+  }
+  else
+      ...
+}
+*/

--- a/include/kernel/ChunkedDecoder.hpp
+++ b/include/kernel/ChunkedDecoder.hpp
@@ -1,0 +1,20 @@
+#include <sstream>
+#include <iomanip>
+#include <stdexcept>
+#include <string>
+#include "IDecoder.hpp"
+
+class ChunkedDecoder : public IDecoder
+{
+  public:
+    ChunkedDecoder();
+    ChunkedDecoder(const ChunkedDecoder& other);
+    ChunkedDecoder& operator=(const ChunkedDecoder& other);
+    ~ChunkedDecoder();
+
+    std::string decode(std::istream& is);
+
+  private:
+    int _hex_to_int(char c);
+    std::string _decode_chunk(std::istream& is);
+};

--- a/include/kernel/GzipDecoder.hpp
+++ b/include/kernel/GzipDecoder.hpp
@@ -1,0 +1,16 @@
+#include <zlib.h>
+#include "IDecoder.hpp"
+
+class GzipDecoder : public IDecoder
+{
+  public:
+    GzipDecoder();
+    GzipDecoder(const GzipDecoder& other);
+    GzipDecoder& operator=(const GzipDecoder& other);
+    ~GzipDecoder();
+
+    std::string decode(std::istream& is);
+
+  private:
+    z_stream _zstream;
+};

--- a/include/kernel/IDecoder.hpp
+++ b/include/kernel/IDecoder.hpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <istream>
+#include <string>
+
+class IDecoder
+{
+  public:
+    virtual ~IDecoder();
+
+    virtual std::string decode(std::istream& is) = 0;
+};


### PR DESCRIPTION
This is a prepared PR for kernel to decode the body depend on header correctly.
- [x] Merge #42 first

@yenthing 
According to RFC 7230, the RequestAnalyzer should record and process specific headers when handling requests with chunked transfer encoding. The relevant headers include:

Transfer-Encoding: This header is crucial as it indicates that the message body is encoded in chunks. The Transfer-Encoding header must include the value chunked if the message body is being sent using chunked transfer encoding.

RFC 7230, Section 4.1 states:

"A sender MUST NOT send a Transfer-Encoding header field in any message other than a chunked transfer coding, unless the Content-Length header field is present."

Content-Length: In the context of chunked transfer encoding, this header should not be present. If Content-Length is included in a request that uses chunked transfer encoding, it may indicate an error or an attempt to misuse the chunked encoding.

RFC 7230, Section 3.3.2 specifies:

"A Content-Length header field is not allowed in a request message when Transfer-Encoding is set to chunked."