### PR TITLE
[CHORE] Use all CPU cores for compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ DEPS		= $(patsubst $(SRC_DIR)/%.cpp, $(DEP_DIR)/%.d, $(SRCS))
 
 INCFLAGS	= $(shell find $(INC_DIR) -type d -exec echo -I{} \;)
 
+MAKEFLAGS	= -j
+
 all: $(NAME)
 
 $(NAME): $(OBJS) $(DEPS)
@@ -38,7 +40,8 @@ clean:
 fclean: clean
 	rm -f $(NAME)
 
-re: fclean all
+re: fclean
+	$(MAKE) all
 
 .PHONY: all clean fclean re
 


### PR DESCRIPTION
This speeds up compilation significantly.

The `MAKEFLAGS` is a default variable of Make. Whatever Make option you assign to it is the same as if you would run `make` with that option.
Assigning the `-j` option lets Make always run with that option, even when it wasn't given in the command line.
> [!NOTE]
> `-j` stands for "jobs" (`--jobs`).

The `re` target had to be slightly changed so that its calls to `fclean` and `all` don't run in parallel. Having `fclean` as a prerequisite and then calling `all` in the recipe ensures that.