### PR TITLE
[DEVOPS] Fix commit message checks (this time for real)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           excludeDescription: 'false'  # Check the entire commit message
           excludeTitle: 'false'  # Do not exclude the title
           checkAllCommitMessages: 'false'  # Check only the PR title, assuming it's the first commit
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch')
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
       - name: Check Commit Type Format
         uses: gsactions/commit-message-checker@v2
         with:
@@ -54,14 +54,14 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
-        if: (!contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch'))
+        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
       - name: Check Verb
         run: .github/scripts/is_verb.sh
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        if: (!contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch'))
+        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
 
   compilation_test:
     name: Compilation Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           excludeDescription: 'false'  # Check the entire commit message
           excludeTitle: 'false'  # Do not exclude the title
           checkAllCommitMessages: 'false'  # Check only the PR title, assuming it's the first commit
-        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
       - name: Check Commit Type Format
         uses: gsactions/commit-message-checker@v2
         with:
@@ -55,14 +55,14 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
-        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
+        if: ${{ !cancelled() }}
       - name: Check Verb
         run: .github/scripts/is_verb.sh
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
+        if: ${{ !cancelled() }}
 
   compilation_test:
     name: Compilation Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Check Title Format
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '\[(DOCS|FEAT|FIX|STYLE|DEVOPS|REFACTOR|PERF|TEST|CHORE)\] .+$'
+          pattern: '\[(FEAT|FIX|DOCS|STYLE|REFACTOR|PERF|TEST|CHORE|DEVOPS|REVERT)\] .+$'
           error: 'Your PR title must contain a commit type like "[FIX]".'
           excludeDescription: 'false'  # Check the entire commit message
           excludeTitle: 'false'  # Do not exclude the title
@@ -39,7 +39,7 @@ jobs:
       - name: Check Commit Type Format
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(feat|fix|docs|style|refactor|perf|test|chore|devops): .*|^Merge pull request #[0-9]+ from [\w\-]+\/[\w\-].*'
+          pattern: '^(feat|fix|docs|style|refactor|perf|test|chore|devops|revert): .*|^Merge pull request #[0-9]+ from [\w\-]+\/[\w\-].*'
           error: 'Commit message must follow the format "<type>: <description>". Valid types: feat, fix, docs, style, refactor, perf, test, chore.'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           excludeDescription: 'false'  # Check the entire commit message
           excludeTitle: 'false'  # Do not exclude the title
           checkAllCommitMessages: 'false'  # Check only the PR title, assuming it's the first commit
-        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
       - name: Check Commit Type Format
         uses: gsactions/commit-message-checker@v2
         with:
@@ -45,6 +45,7 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
+        if: ${{ !cancelled() }}
       - name: Check Line Length
         uses: gsactions/commit-message-checker@v2
         with:
@@ -54,14 +55,14 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
-        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
+        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
       - name: Check Verb
         run: .github/scripts/is_verb.sh
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') }}
+        if: ${{ !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch') && !cancelled() }}
 
   compilation_test:
     name: Compilation Test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           excludeDescription: 'false'  # Check the entire commit message
           excludeTitle: 'false'  # Do not exclude the title
           checkAllCommitMessages: 'false'  # Check only the PR title, assuming it's the first commit
-        if: github.event_name == 'pull_request' && ${{ !github.event.pull_request.merged }} && ${{ !cancelled() }}
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch')
       - name: Check Commit Type Format
         uses: gsactions/commit-message-checker@v2
         with:
@@ -45,7 +45,6 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
-        if: ${{ !cancelled() }}
       - name: Check Line Length
         uses: gsactions/commit-message-checker@v2
         with:
@@ -55,14 +54,14 @@ jobs:
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
-        if: ${{ !github.event.pull_request.merged }} && ${{ !cancelled() }}
+        if: (!contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch'))
       - name: Check Verb
         run: .github/scripts/is_verb.sh
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        if: ${{ !github.event.pull_request.merged }} && ${{ !cancelled() }}
+        if: (!contains(github.event.pull_request.title, 'Merge pull request') && !contains(github.event.pull_request.title, 'Merge branch'))
 
   compilation_test:
     name: Compilation Test


### PR DESCRIPTION
- True fix for #96 and #83 
- Allow `revert` commit keyword

> [!NOTE]
> #### Reminder what this is trying to achieve
> For the commit message checks, even if step 1 fails, the following steps will still run (failed steps still cause the whole job to fail).
> This way you can see all issues with the commit messages at once and don't have to rerun the action after each fix.

---

This time I tested it in my own fork and have now proof that it actually works:

![image](https://github.com/user-attachments/assets/d818e9df-b2eb-4cc8-becc-125f23797ba9)
https://github.com/itislu/webserver/actions 
<br>
![image](https://github.com/user-attachments/assets/8b830bf9-ce05-4838-910c-9eaab6269f2c)
https://github.com/itislu/webserver/actions/runs/12076965162/job/33679132759