### PR TITLE
[FEAT] Remove dot segments from URI path

### DIFF
--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -46,6 +46,8 @@ class UriAnalyzer
     bool _valid_hexdigit(unsigned char c);
 
     std::string _remove_dot_segments() const;
+    void _remove_last_segment(std::string& str) const;
+    void _move_first_segment(std::string& from, std::string& to) const;
 
     // std::string _scheme; //we dont really need this for anything
     std::string _uri;

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -45,6 +45,8 @@ class UriAnalyzer
     unsigned char _hexval(unsigned char c);
     bool _valid_hexdigit(unsigned char c);
 
+    std::string _remove_dot_segments() const;
+
     // std::string _scheme; //we dont really need this for anything
     std::string _uri;
     std::string _host;

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/04 21:45:11 by mhuszar          ###   ########.fr       */
+/*   Updated: 2024/12/04 22:11:38 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,11 +76,59 @@ void UriAnalyzer::reset()
     _fragment = "";
 }
 
+void UriAnalyzer::_remove_last_segment(std::string& str) const
+{
+    size_t pos = str.find_last_of('/');
+    if (pos != std::string::npos)
+        str.erase(pos);
+}
+
+void UriAnalyzer::_move_first_segment(std::string& from, std::string& to) const
+{
+    size_t pos = from[0] == '/';
+    pos = from.find('/', pos);
+    if (pos != std::string::npos)
+    {
+        to += from.substr(0, pos);
+        from = from.substr(pos);
+    }
+    else
+    {
+        to += from;
+        from.clear();
+    }
+}
+
 std::string UriAnalyzer::_remove_dot_segments() const
 {
     std::string input_buffer;
     std::string output_buffer;
 
+    while (!input_buffer.empty())
+    {
+        if (input_buffer.substr(0, 3) == "../")
+            input_buffer = input_buffer.substr(3);
+        else if (input_buffer.substr(0, 2) == "./")
+            input_buffer = input_buffer.substr(2);
+        else if (input_buffer.substr(0, 3) == "/./")
+            input_buffer = input_buffer.substr(2);
+        else if (input_buffer == "/.")
+            input_buffer = "/";
+        else if (input_buffer.substr(0, 3) == "/../")
+        {
+            input_buffer = input_buffer.substr(3);
+            _remove_last_segment(output_buffer);
+        }
+        else if (input_buffer == "/..")
+        {
+            input_buffer = "/";
+            _remove_last_segment(output_buffer);
+        }
+        else if (input_buffer == ".." || input_buffer == ".")
+            input_buffer.clear();
+        else
+            _move_first_segment(input_buffer, output_buffer);
+    }
     return (output_buffer);
 }
 

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/04 22:11:38 by mhuszar          ###   ########.fr       */
+/*   Updated: 2024/12/04 22:26:49 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,7 +101,7 @@ void UriAnalyzer::_move_first_segment(std::string& from, std::string& to) const
 
 std::string UriAnalyzer::_remove_dot_segments() const
 {
-    std::string input_buffer;
+    std::string input_buffer = _path;
     std::string output_buffer;
 
     while (!input_buffer.empty())
@@ -114,7 +114,7 @@ std::string UriAnalyzer::_remove_dot_segments() const
             input_buffer = input_buffer.substr(2);
         else if (input_buffer == "/.")
             input_buffer = "/";
-        else if (input_buffer.substr(0, 3) == "/../")
+        else if (input_buffer.substr(0, 4) == "/../")
         {
             input_buffer = input_buffer.substr(3);
             _remove_last_segment(output_buffer);
@@ -140,7 +140,7 @@ Uri UriAnalyzer::take_uri() const
     ret.authority = _host + ":" + _port;
     ret.host = _host;
     ret.port = _port;
-    ret.path = _remove_dot_segments();//_path;
+    ret.path = _remove_dot_segments();
     ret.query = _query;
     ret.fragment = _fragment;
     return (ret);

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,13 +6,12 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/03 21:18:05 by mhuszar          ###   ########.fr       */
+/*   Updated: 2024/12/04 21:45:11 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "UriAnalyzer.hpp"
 #include "HttpException.hpp"
-#include <sstream>
 
 namespace webshell
 {
@@ -77,6 +76,14 @@ void UriAnalyzer::reset()
     _fragment = "";
 }
 
+std::string UriAnalyzer::_remove_dot_segments() const
+{
+    std::string input_buffer;
+    std::string output_buffer;
+
+    return (output_buffer);
+}
+
 Uri UriAnalyzer::take_uri() const
 {
     Uri ret;
@@ -85,7 +92,7 @@ Uri UriAnalyzer::take_uri() const
     ret.authority = _host + ":" + _port;
     ret.host = _host;
     ret.port = _port;
-    ret.path = _path;
+    ret.path = _remove_dot_segments();//_path;
     ret.query = _query;
     ret.fragment = _fragment;
     return (ret);


### PR DESCRIPTION
This function is a simple but integral part of path normalization. Implemented exactly as per described in RFC 3986 5.2.4.

Example from RFC:

![image](https://github.com/user-attachments/assets/7f195939-0bc9-4910-ba5e-224e2fd02c48)

Same example from my parser:

![image](https://github.com/user-attachments/assets/8285c784-abfe-444c-82e2-294b747bb634)
