### PR TITLE
[FIX] Remove frontend upload file via chunks button

### DIFF
--- a/tests/upload_chunks.sh
+++ b/tests/upload_chunks.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Variables
+file="$1"        # File to upload
+url="$2"         # Target server URL
+chunk_size="$3"  # Chunk size in bytes
+
+if [[ -z "$file" || -z "$url" || -z "$chunk_size" ]]; then
+    echo "Usage: $0 <file> <url> <chunk_size>"
+    exit 1
+fi
+
+# Ensure the file exists
+if [[ ! -f "$file" ]]; then
+    echo "File not found: $file"
+    exit 1
+fi
+
+# Read file size
+file_size=$(stat -c%s "$file")
+echo "Uploading $file ($file_size bytes) to $url with chunk size $chunk_size bytes"
+
+# Offset to track how much data has been read
+offset=0
+
+# Process the first chunk with headers
+chunk=$(dd if="$file" bs=1 count="$chunk_size" skip=$offset 2>/dev/null)
+if [[ -n "$chunk" ]]; then
+    echo "Sending first chunk with headers..."
+    curl -X POST \
+         -H "X-File-Name: $(basename "$file")" \
+         -H "Transfer-Encoding: chunked" \
+         -H "Content-Type: application/octet-stream" \
+         --data-binary "$chunk" \
+         "$url"
+    offset=$((offset + chunk_size))
+fi
+
+# Send subsequent chunks without headers
+while [[ $offset -lt $file_size ]]; do
+    chunk=$(dd if="$file" bs=1 count="$chunk_size" skip=$offset 2>/dev/null)
+
+    if [[ -z "$chunk" ]]; then
+        break
+    fi
+
+    echo "Sending subsequent chunk from offset $offset..."
+    curl -X POST \
+         --data-binary "$chunk" \
+         "$url"
+
+    offset=$((offset + chunk_size))
+done
+
+echo "Upload complete."

--- a/www/html/upload.html
+++ b/www/html/upload.html
@@ -92,7 +92,6 @@
             <div id="myDropzone" class="dropzone"></div>
             <div class="upload-buttons">
                 <button id="uploadEntire" class="upload-button">Upload Entire File</button>
-                <button id="uploadChunked" class="upload-button">Upload via Chunks</button>
             </div>
             <div id="message-area"></div>
         </section>
@@ -189,53 +188,6 @@
             };
 
             reader.readAsArrayBuffer(file);
-        });
-
-        document.getElementById('uploadChunked').addEventListener('click', async function () {
-            if (myDropzone.files.length === 0) {
-                showMessage('Please add a file first.', true);
-                return;
-            }
-
-            const file = myDropzone.files[0];
-            const chunkSize = 1024 * 1024; // 1MB chunks
-            const totalChunks = Math.ceil(file.size / chunkSize);
-
-            for (let i = 0; i < totalChunks; i++) {
-                const start = i * chunkSize;
-                const end = Math.min(start + chunkSize, file.size);
-                const chunk = file.slice(start, end);
-
-                const reader = new FileReader();
-                reader.onload = async function (event) {
-                    try {
-                        const response = await fetch(serverUrl, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/octet-stream',
-                                'Content-Range': `bytes ${start}-${end - 1}/${file.size}`,
-                            },
-                            body: event.target.result,
-                        });
-
-                        const result = await handleResponse(response);
-                        if (!result.success) {
-                            throw new Error(result.message);
-                        }
-
-                        showMessage(`Uploaded chunk ${i + 1}/${totalChunks}`);
-                    } catch (error) {
-                        console.error('Error:', error);
-                        showMessage(`Chunk ${i + 1} failed to upload: ${error.message}`, true);
-                        return;
-                    }
-                };
-
-                reader.readAsArrayBuffer(chunk);
-                await new Promise(resolve => reader.onloadend = resolve);
-            }
-
-            showMessage('All chunks uploaded successfully');
         });
     </script>
 </body>


### PR DESCRIPTION
- [x] Need to merge #115 first

for the security issue the modern browser will filter out the `Transfer-Encoding` header, so we cannot test in this way.

so I create this test script

```sh
Usage: ./upload_chunks.sh <file> <url>
╭─lyeh at c4r6p1 in ~/project/curriculum/webserver/tests on fix-frontend-upload-chunk✘✘✘ 24-12-13 - 11:58:03
╰─⠠⠵ ./upload_chunks.sh connection_test.go 127.0.0.1:8081/upload
```