### PR TITLE
[FEAT] Add state machine for parsing request body

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -117,10 +117,10 @@ enum URIState
 enum ChunkState
 {
     CHUNKSIZE = 0,
-    SIZE_CR,
+    SIZE_CRLF,
     SIZE_LF,
     CHUNKBODY,
-    BODY_CR,
+    BODY_CRLF,
     BODY_LF
 };
 

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -114,6 +114,16 @@ enum URIState
     END_URI_PARSER
 };
 
+enum ChunkState
+{
+    CHUNKSIZE = 0,
+    SIZE_CR,
+    SIZE_LF,
+    CHUNKBODY,
+    BODY_CR,
+    BODY_LF
+};
+
 enum CacheState
 {
     C_ERROR = -1,

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -118,10 +118,10 @@ enum ChunkState
 {
     CHUNKSIZE = 0,
     SIZE_CRLF,
-    SIZE_LF,
+    // SIZE_LF,
     CHUNKBODY,
     BODY_CRLF,
-    BODY_LF
+    // BODY_LF
 };
 
 enum CacheState

--- a/include/kernel/PostHandler.hpp
+++ b/include/kernel/PostHandler.hpp
@@ -35,7 +35,7 @@ class PostHandler : public ARequestHandler
     std::string _determine_content_type(const webshell::Request& request);
     std::string _generate_safe_file_path(const webshell::Request& request);
 
-    void _write_chunked_file(int fd, const std::string& content);
+    void _write_chunked_file(int fd, const std::vector<char>& content);
 
   private:
     PostHandler(const PostHandler& other);

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -3,6 +3,7 @@
 #include "RequestConfig.hpp"
 #include "Uri.hpp"
 #include "defines.hpp"
+#include <cstddef>
 #include <map>
 #include <string>
 
@@ -56,6 +57,7 @@ class Request
     size_t _processed;
     ChunkState _state;
     std::string _chunksize;
+    size_t _size_num;
     std::string _chunkbuf;
 
     RequestMethod _method;

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -31,34 +31,32 @@ class Request
     bool empty_buffer() const;
     bool has_header(const std::string& name) const;
 
-    bool read_chunked_body(std::string& chunked_body);
+    bool read_chunked_body(std::vector<char>& chunked_body);
 
     void setMethod(RequestMethod method);
     void setUri(Uri uri);
     void setVersion(float version);
     void setHeaders(std::map<std::string, std::string> headers);
-    void setBody(std::string& body);
+    // void setBody(std::string& body);
     void addHeader(std::string& name, std::string& value);
     void setReference(std::string* read_buffer);
     bool setupRequestConfig(int server_id);
 
   private:
-    bool _proceed_content_len(std::string& chunked_body);
-    bool _proceed_chunked(std::string& chunked_body);
+    bool _proceed_content_len(std::vector<char>& chunked_body);
+    bool _proceed_chunked(std::vector<char>& chunked_body);
 
     void _check_hexdigit(unsigned char c);
     void _check_size_crlf(unsigned char c);
-    // void _check_size_lf(unsigned char c);
     void _check_body(unsigned char c);
     bool _check_body_crlf(unsigned char c);
-    // void _check_body_lf(unsigned char c);
 
     webkernel::ChunkedCodec _codec;
     size_t _processed;
     ChunkState _state;
     std::string _chunksize;
     size_t _size_num;
-    std::string _chunkbuf;
+    std::vector<char> _chunkbuf;
 
     RequestMethod _method;
     Uri _uri;

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -46,15 +46,16 @@ class Request
     bool _proceed_chunked(std::string& chunked_body);
 
     void _check_hexdigit(unsigned char c);
-    void _check_size_cr(unsigned char c);
-    void _check_size_lf(unsigned char c);
+    void _check_size_crlf(unsigned char c);
+    // void _check_size_lf(unsigned char c);
     void _check_body(unsigned char c);
-    void _check_body_cr(unsigned char c);
-    void _check_body_lf(unsigned char c);
+    bool _check_body_crlf(unsigned char c);
+    // void _check_body_lf(unsigned char c);
 
     webkernel::ChunkedCodec _codec;
     size_t _processed;
     ChunkState _state;
+    std::string _chunksize;
     std::string _chunkbuf;
 
     RequestMethod _method;

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -49,7 +49,7 @@ class Request
     void _check_hexdigit(unsigned char c);
     void _check_size_crlf(unsigned char c);
     void _check_body(unsigned char c);
-    bool _check_body_crlf(unsigned char c);
+    void _check_body_crlf(unsigned char c);
 
     webkernel::ChunkedCodec _codec;
     size_t _processed;

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -45,8 +45,17 @@ class Request
     bool _proceed_content_len(std::string& chunked_body);
     bool _proceed_chunked(std::string& chunked_body);
 
+    void _check_hexdigit(unsigned char c);
+    void _check_size_cr(unsigned char c);
+    void _check_size_lf(unsigned char c);
+    void _check_body(unsigned char c);
+    void _check_body_cr(unsigned char c);
+    void _check_body_lf(unsigned char c);
+
     webkernel::ChunkedCodec _codec;
     size_t _processed;
+    ChunkState _state;
+    std::string _chunkbuf;
 
     RequestMethod _method;
     Uri _uri;

--- a/source/kernel/PostHandler.cpp
+++ b/source/kernel/PostHandler.cpp
@@ -116,7 +116,7 @@ std::string PostHandler::_process(int fd, EventProcessingState& state,
         _upload_record_pool[fd] =
             new UploadRecord(_generate_safe_file_path(request), content_length);
     }
-    std::string content;
+    std::vector<char> content;
     bool is_eof = request.read_chunked_body(content);
 
     _write_chunked_file(fd, content);
@@ -220,7 +220,7 @@ PostHandler::_generate_safe_file_path(const webshell::Request& request)
     return (safe_file_path);
 }
 
-void PostHandler::_write_chunked_file(int fd, const std::string& content)
+void PostHandler::_write_chunked_file(int fd, const std::vector<char>& content)
 {
     if (_upload_record_pool.find(fd) == _upload_record_pool.end())
         throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
@@ -236,7 +236,7 @@ void PostHandler::_write_chunked_file(int fd, const std::string& content)
     {
         size_t write_size =
             std::min(remaining, (size_t)webkernel::CHUNKED_SIZE);
-        file_stream->write(content.c_str() + offset, write_size);
+        file_stream->write(content.data() + offset, write_size);
         offset += write_size;
         remaining -= write_size;
     }

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -209,60 +209,11 @@ bool Request::_proceed_content_len(std::string& chunked_body)
 
 bool Request::_proceed_chunked(std::string& chunked_body)
 {
-    static size_t max_payload = _config.client_max_body_size;
-    static std::string buffer;
-    static size_t crlf_ctr = 0;
-
-    size_t pos = (*_read_buffer).find(CRLF);
-    if (pos == std::string::npos)
-    {
-        if (buffer.size() > webkernel::BUFFER_SIZE)
-            throw utils::HttpException(webshell::PAYLOAD_TOO_LARGE,
-                "Chunk size should not exceed BUFFER SIZE");
-        buffer += (*_read_buffer);
-        (*_read_buffer).clear();
-        chunked_body = "";
-        return false;
-    }
-    else if (crlf_ctr == 1)
-    {
-        buffer += (*_read_buffer).substr(0, pos + 2);
-        (*_read_buffer) = (*_read_buffer).substr(pos + 2);
-        crlf_ctr = 0;
-    }
-    else
-    {
-        size_t pos_2nd = (*_read_buffer).find(CRLF, pos + 2);
-        if (pos_2nd == std::string::npos)
-        {
-            if (buffer.size() > webkernel::BUFFER_SIZE)
-                throw utils::HttpException(webshell::PAYLOAD_TOO_LARGE,
-                    "Chunk size should not exceed BUFFER SIZE");
-            buffer += (*_read_buffer);
-            (*_read_buffer).clear();
-            chunked_body = "";
-            crlf_ctr = 1;
-            return false;
-        }
-        buffer += (*_read_buffer).substr(0, pos_2nd + 2);
-        (*_read_buffer) = (*_read_buffer).substr(pos_2nd + 2);
-    }
-
-    try
-    {
-        chunked_body = _codec.decode_single(buffer);
-        buffer.clear();
-    }
-    catch (OperationInterrupt& e)
-    {
-        _processed = 0;
-        return (true);
-    }
-    _processed += chunked_body.size();
-    if (_processed > max_payload)
-        throw utils::HttpException(
-            webshell::PAYLOAD_TOO_LARGE,
-            "Chunked data size exceeds client_max_body_size");
+    // static size_t max_payload = _config.client_max_body_size;
+    // static std::string buffer;
+    // static size_t crlf_ctr = 0;
+    (void) chunked_body;
+    
     return (false);
 }
 
@@ -313,9 +264,44 @@ bool Request::setupRequestConfig(int server_id)
     return (true);
 }
 
-// void Request::setBody(std::string& body)
-// {
-//     _body = body;
-// }
+void Request::_check_hexdigit(unsigned char c)
+{
+    _chunkbuf.push_back(c);
+    if (isdigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
+        return ;
+    else if (c == '\r')
+    {
+        _state = SIZE_CR;
+        return ;
+    }
+    throw utils::HttpException(webshell::BAD_REQUEST,
+                "Malformed chunk size: should be hexdigit",
+                                   webshell::TEXT_PLAIN);
+}
+
+void Request::_check_size_cr(unsigned char c)
+{
+    (void)c;
+}
+
+void Request::_check_size_lf(unsigned char c)
+{
+    (void)c;
+}
+
+void Request::_check_body(unsigned char c)
+{
+    (void)c;
+}
+
+void Request::_check_body_cr(unsigned char c)
+{
+    (void)c;
+}
+
+void Request::_check_body_lf(unsigned char c)
+{
+    (void)c;
+}
 
 } // namespace webshell

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -239,7 +239,7 @@ bool Request::_proceed_chunked(std::string& chunked_body)
                 if (_check_body_crlf(c))
                 {
                     chunked_body = _chunkbuf;
-                    (*_read_buffer) = (*_read_buffer).substr(idx);
+                    (*_read_buffer) = (*_read_buffer).substr(idx + 1);
                     _chunksize.clear();
                     if (_chunkbuf.empty())
                         return (true);

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -3,6 +3,7 @@
 #include "ConfigHttpBlock.hpp"
 #include "ConfigLocationBlock.hpp"
 #include "HttpException.hpp"
+#include "Logger.hpp"
 #include "OperationInterrupt.hpp"
 #include "Uri.hpp"
 #include "defines.hpp"
@@ -239,10 +240,12 @@ bool Request::_proceed_chunked(std::string& chunked_body)
                 {
                     chunked_body = _chunkbuf;
                     (*_read_buffer) = (*_read_buffer).substr(idx);
+                    _chunksize.clear();
+                    if (_chunkbuf.empty())
+                        return (true);
                     _processed += _chunkbuf.size();
                     _chunkbuf.clear();
-                    _chunksize.clear();
-                    return (true);
+                    return (false);
                 }
                 break;
             }

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <ios>
 #include <iostream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 // #include <sys/siginfo.h>
@@ -23,19 +24,19 @@ namespace webshell
 {
 
 Request::Request()
-    : _processed(0), _size_num(-1), _method(UNKNOWN), _uri(), _version(), _headers(),
+    : _processed(0), _state(CHUNKSIZE), _size_num(-1), _method(UNKNOWN), _uri(), _version(), _headers(),
       _read_buffer()
 {
 }
 
 Request::Request(std::string* buffer)
-    : _processed(0), _method(UNKNOWN), _uri(), _version(), _headers(),
+    : _processed(0), _state(CHUNKSIZE), _size_num(-1), _method(UNKNOWN), _uri(), _version(), _headers(),
       _read_buffer(buffer)
 {
 }
 
 Request::Request(const Request& other)
-    : _processed(other._processed), _method(other._method), _uri(other._uri),
+    : _processed(other._processed), _state(other._state), _size_num(other._size_num), _method(other._method), _uri(other._uri),
       _version(other._version), _headers(other._headers),
       _read_buffer(other._read_buffer), _config(other._config)
 {
@@ -46,6 +47,8 @@ Request& Request::operator=(const Request& other)
     if (this != &other)
     {
         _processed = other._processed;
+        _state = other._state;
+        _size_num = other._size_num;
         _method = other._method;
         _uri = other._uri;
         _version = other._version;


### PR DESCRIPTION
I have turned the function into state machine as requested.

Okay it is not actually a state machine, because it handles everything else too. I figured since we inspect every single character now, we don't need the codec anymore. I can just separate the characters i need into chunk size and chunk body itself while parsing, just like at parsing the request line. But i added also the validation checks which go beyond state machine functionality (like payload too large or not mismatched size), i do not think it would make much sense to separate.

Can be checked with a huge file if you modify the client_max_body_size in the configfile (otherwise you will get `413`). 

`./chunked_upload http://127.0.0.1:8080/upload OTHER_BIG_FILE_2 100  0.42s user 0.37s system 0% cpu 2:11.01 total` - uploading 100mb file took about 2 minutes, idk what to think about this. Don't do it through VSCode though cause it builds some cache of the uploaded file and then the process uses too much memory and gets killed.
