### PR TITLE
[FEAT] Add percent decoding

### DIFF
--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -41,7 +41,9 @@ class UriAnalyzer
     bool _is_pchar(unsigned char c);
     bool _is_query_or_fragment_part(unsigned char c);
 
-    unsigned char _decode_percent();
+    unsigned char _decode_percent(std::string& str);
+    void _decode(std::string& str);
+    void _percent_decode_all();
     unsigned char _hexval(unsigned char c);
     bool _valid_hexdigit(unsigned char c);
 

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -42,6 +42,7 @@ class UriAnalyzer
     bool _is_query_or_fragment_part(unsigned char c);
 
     unsigned char _decode_percent(std::string& str);
+    unsigned char _decode_num_and_alpha();
     void _decode(std::string& str);
     void _percent_decode_all();
     unsigned char _hexval(unsigned char c);

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   UriAnalyzer.cpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: mhuszar <mhuszar@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/20 21:37:40 by mhuszar          ###   ########.fr       */
+/*   Updated: 2024/12/22 17:24:28 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -453,7 +453,7 @@ unsigned char UriAnalyzer::_decode_num_and_alpha()
     unsigned char value = _hexval(first) * 16 + _hexval(second);
     if (_is_unreserved(value))
     {
-        _idx += 3;
+        _idx += 2;
         return (value);
     }
     return ('%');


### PR DESCRIPTION
#121 should definitely be merged first but anyway this is not ready.

So this feature was more or less missing so far. In RFC 3986 2.4. it is written:
>   When a URI is dereferenced, the components and subcomponents significant to the scheme-specific dereferencing process (if any) must be parsed and separated before the percent-encoded octets within those components can be safely decoded, as otherwise the data may be mistaken for component delimiters.

So i follow this now, first i separate all elements of URI and then put them in the percent decoder function, before that if i see something percent encoded, i just assume its fine and append it to the respective element (according to the current state of state machine). BUT since:
> The only exception is for percent-encoded octets corresponding to characters in the unreserved set, which can be decoded at any time.

Therefore all unreserved characters i decode as i go (otherwise i could not decide for example if host is supposed to be regname or IPV4, cause i don't know if a digit is behind % sign or not).

But we still need to discuss a few things. For example most decoding should be the last step, but i still decided to do it before `remove_dot_segments`, otherwise it could be used as a measure to try to get out of root. So idk how to handle this.
Also in some cases request handler manager seems to throw `501` after using % encoding when i tested, i could not figure out why so @LeaYeh we should have a look at that.