### PR TITLE
[REFACTOR] Change the path parsing in the URI to comply with RFC9112

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -113,6 +113,15 @@ enum URIState
     END_URI_PARSER
 };
 
+enum URIType
+{
+    UNKNOWN_TYPE = -1,
+    ORIGIN = 0,
+    ABSOLUTE,
+    AUTHORITY,
+    ASTERISK
+};
+
 enum ChunkState
 {
     CHUNKSIZE = 0,

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -80,10 +80,10 @@ enum RequestMethod
 {
     UNKNOWN = -1,
     GET = 0,
-    HEAD,
     POST,
-    PUT,
-    DELETE
+    DELETE,
+    CONNECT,
+    OPTIONS
 };
 
 enum RequestLineState

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -101,6 +101,7 @@ enum URIState
 {
     URI_ERROR = -1,
     URI_START = 0,
+    URI_LIMBO,
     URI_SCHEME,
     URI_HOST_TRIAL,
     URI_HOST_IPV4,

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -102,7 +102,6 @@ enum URIState
     URI_ERROR = -1,
     URI_START = 0,
     URI_SCHEME,
-    URI_REL_START,
     URI_HOST_TRIAL,
     URI_HOST_IPV4,
     URI_HOST_REGNAME,

--- a/include/shell/RequestAnalyzer.hpp
+++ b/include/shell/RequestAnalyzer.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 17:34:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/12 17:21:07 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/06 01:20:58 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,7 @@ class RequestAnalyzer
     RequestLineAnalyzer _rl_analyzer;
     HeaderAnalyzer _header_analyzer;
     void _assemble_request(void);
+    void _validate_method_and_uri();
 
     // webconfig::RequestConfig* _config;
     int _server_id;

--- a/include/shell/Uri.hpp
+++ b/include/shell/Uri.hpp
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   Uri.hpp                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhuszar <mhuszar@student.42.fr>            +#+  +:+       +#+        */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:18:11 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/03 20:12:48 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/06 01:15:37 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
+#include "defines.hpp"
 #include <string>
 
 namespace webshell
@@ -26,7 +27,7 @@ struct Uri
     std::string path;
     std::string query;
     std::string fragment;
-    bool _origin_form;
+    URIType type;
     // std::string userinfo; //TODO: put test case
 };
 

--- a/include/shell/Uri.hpp
+++ b/include/shell/Uri.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Uri.hpp                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*   By: mhuszar <mhuszar@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:18:11 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/11/09 18:20:03 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/03 20:12:48 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ struct Uri
     std::string path;
     std::string query;
     std::string fragment;
+    bool _origin_form;
     // std::string userinfo; //TODO: put test case
 };
 

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -59,8 +59,10 @@ class UriAnalyzer
     std::string _path;
     std::string _query;
     std::string _fragment;
+    std::string _temp_buf;
 
     URIState _state;
+    URIType _type;
     unsigned int _idx;
     int _sidx;
 

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -66,5 +66,7 @@ class UriAnalyzer
 
     bool _ipv_digit;
     int _ipv_dot;
+
+    bool _origin_form;
 };
 } // namespace webshell

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -24,6 +24,7 @@ class UriAnalyzer
     void _feed(unsigned char c);
 
     void _uri_start(unsigned char c);
+    void _uri_limbo(unsigned char c);
     void _uri_rel_start(unsigned char c);
     void _uri_scheme(unsigned char c);
     void _uri_host_trial(unsigned char c);
@@ -47,6 +48,7 @@ class UriAnalyzer
     void _percent_decode_all();
     unsigned char _hexval(unsigned char c);
     bool _valid_hexdigit(unsigned char c);
+    unsigned char _lowcase(unsigned char c);
 
     std::string _remove_dot_segments() const;
     void _remove_last_segment(std::string& str) const;
@@ -69,6 +71,5 @@ class UriAnalyzer
     bool _ipv_digit;
     int _ipv_dot;
 
-    bool _origin_form;
 };
 } // namespace webshell

--- a/source/shell/RequestAnalyzer.cpp
+++ b/source/shell/RequestAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 17:34:34 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/12/12 17:20:56 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/06 01:26:02 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,6 +71,7 @@ void RequestAnalyzer::feed(const char ch)
             _method = _rl_analyzer.method();
             _header_analyzer.set_method(_method);
             _uri = _rl_analyzer.uri();
+            _validate_method_and_uri();
             _version = _rl_analyzer.version();
         }
         break;
@@ -89,6 +90,18 @@ void RequestAnalyzer::feed(const char ch)
         throw std::runtime_error("Request parse error");
     }
     }
+}
+
+void RequestAnalyzer::_validate_method_and_uri()
+{
+    if ((_method == CONNECT && _uri.type == AUTHORITY)
+        || (_method == OPTIONS && _uri.type == ASTERISK)
+        || _method == UNKNOWN)
+        throw utils::HttpException(webshell::NOT_IMPLEMENTED,
+                "Only GET, POST and DELETE method supported");
+    else if (_uri.type == AUTHORITY || _uri.type == ASTERISK)
+        throw utils::HttpException(webshell::BAD_REQUEST,
+                "Please use origin or absolute form");
 }
 
 bool RequestAnalyzer::isComplete(void) const

--- a/source/shell/RequestLineAnalyzer.cpp
+++ b/source/shell/RequestLineAnalyzer.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   RequestLineAnalyzer.cpp                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mhuszar <mhuszar@student.42.fr>            +#+  +:+       +#+        */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 16:52:31 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/03 18:02:04 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/06 01:22:54 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,14 @@ RequestMethod RequestLineAnalyzer::method() const
     {
         return (DELETE);
     }
+    else if (_method == "CONNECT")
+    {
+        return (CONNECT);
+    }
+    else if (_method == "OPTIONS")
+    {
+        return (OPTIONS);
+    }
     else
     {
         return (UNKNOWN);
@@ -95,7 +103,7 @@ void RequestLineAnalyzer::feed(unsigned char ch)
         case URI:
         {
             if (_collect_uri(ch))
-                 _uri_analyzer.parse_uri(_uri);
+                _uri_analyzer.parse_uri(_uri);
             break;
         }
         case VERSION:

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/06 01:16:12 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/06 01:32:34 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -211,6 +211,9 @@ void UriAnalyzer::_feed(unsigned char c)
         case URI_START:
             _uri_start(c);
             break;
+        case URI_LIMBO:
+            _uri_limbo(c);
+            break;
         case URI_SCHEME:
             _uri_scheme(c);
             break;
@@ -238,6 +241,11 @@ void UriAnalyzer::_feed(unsigned char c)
         case URI_FRAGMENT: //str does not contain #
             _uri_fragment(c);
             break;
+        case END_URI_PARSER:
+        {
+            throw utils::HttpException(webshell::BAD_REQUEST,
+                "Asterisk form should only contain *");
+        }
         default:
         {
             throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/03 20:11:12 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/05 17:43:08 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,9 @@ UriAnalyzer::UriAnalyzer()
     _port = "";
     _query = "";
     _fragment = "";
+    _temp_buf = "";
     _state = URI_START;
+    _type = UNKNOWN_TYPE;
     _idx = 0;
     _sidx = 0;
     _ipv_digit = false;
@@ -36,8 +38,9 @@ UriAnalyzer::UriAnalyzer()
 
 UriAnalyzer::UriAnalyzer(const UriAnalyzer& other)
     : _uri(other._uri), _host(other._host), _port(other._port), _path(other._path),
-        _query(other._query), _fragment(other._fragment), _state(other._state), _idx(other._idx),
-            _sidx(other._sidx), _ipv_digit(other._ipv_digit), _ipv_dot(other._ipv_dot), _origin_form(other._origin_form)
+        _query(other._query), _fragment(other._fragment), _temp_buf(other._temp_buf),
+        _state(other._state), _type(other._type), _idx(other._idx), _sidx(other._sidx), _ipv_digit(other._ipv_digit),
+        _ipv_dot(other._ipv_dot), _origin_form(other._origin_form)
 {
 }
 
@@ -51,7 +54,9 @@ UriAnalyzer& UriAnalyzer::operator=(const UriAnalyzer& other)
         _path = other._path;
         _query = other._query;
         _fragment = other._fragment;
+        _temp_buf = other._temp_buf;
         _state = other._state;
+        _type = other._type;
         _idx = other._idx;
         _sidx = other._sidx;
         _ipv_digit = other._ipv_digit;
@@ -73,7 +78,9 @@ void UriAnalyzer::reset()
     _port = "";
     _query = "";
     _fragment = "";
+    _temp_buf = "";
     _state = URI_START;
+    _type = UNKNOWN_TYPE;
     _idx = 0;
     _sidx = 0;
     _ipv_digit = false;

--- a/source/utils/configUtils.cpp
+++ b/source/utils/configUtils.cpp
@@ -100,9 +100,7 @@ webshell::RequestMethod string_to_request_method(const std::string& value)
     if (request_method_map.empty())
     {
         request_method_map["GET"] = webshell::GET;
-        request_method_map["HEAD"] = webshell::HEAD;
         request_method_map["POST"] = webshell::POST;
-        request_method_map["PUT"] = webshell::PUT;
         request_method_map["DELETE"] = webshell::DELETE;
     }
 

--- a/source/utils/shellUtils.cpp
+++ b/source/utils/shellUtils.cpp
@@ -1,4 +1,5 @@
 #include "shellUtils.hpp"
+#include "defines.hpp"
 
 namespace webshell
 {
@@ -58,14 +59,14 @@ std::string requestMethodToString(webshell::RequestMethod method)
     {
     case webshell::GET:
         return ("GET");
-    case webshell::HEAD:
-        return ("HEAD");
     case webshell::POST:
         return ("POST");
-    case webshell::PUT:
-        return ("PUT");
     case webshell::DELETE:
         return ("DELETE");
+    case webshell::CONNECT:
+        return ("CONNECT");
+    case webshell::OPTIONS:
+        return ("OPTIONS");
     default:
         return ("UNKNOWN");
     }


### PR DESCRIPTION
So this change had to be done because as Thomas made me aware, RFC9112 (HTTP/1.1) only allows for 4 specific types or request target. As in RFC9112 3.2:
```
request-target = origin-form
                 / absolute-form
                 / authority-form
                 / asterisk-form
```
Out of these four, authority-form is only used for CONNECT, and asterisk-form is only used for OPTIONS requests, therefore we only need to care about the first two.

Absolute-form is formatted as follows:

```
http-URI = "http" "://" authority path-abempty [ "?" query ]
```

Origin-form uses the "absolute-path" rule described in RFC9110 4.1 (not to be confused with "path-absolute" from RFC3986):

```
absolute-path = 1*( "/" segment )
```

Because previously I adhered to RFC3986, my parsing was more permissive, so I needed to delete a state from the URI parser to comply with these restrictions. However, because we do not allow for path-empty (or path-abempty without authority) anymore, this essentially closes #75 

These test cases should now result in `400`:

```
GET  HTTP/1.1
Host: hehe.com

GET http:/index.html HTTP/1.1
Host: hehe.com

GET lol HTTP/1.1
Host: hehe.com
```