### PR TITLE
[FEAT] Add parsing of Cookie header to HeaderFieldAnalyzer

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -149,10 +149,11 @@ enum CacheState
 enum CookieState
 {
     CO_ERROR = -1,
-    CO_OWS = 0,
+    CO_OWS_START = 0,
     CO_NAME,
     CO_VALUE,
-    CO_SP
+    CO_SP,
+    CO_OWS_END
 };
 
 enum RequestHeaderState

--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -146,6 +146,15 @@ enum CacheState
     C_INQUOTE_ESCAPE
 };
 
+enum CookieState
+{
+    CO_ERROR = -1,
+    CO_OWS = 0,
+    CO_NAME,
+    CO_VALUE,
+    CO_SP
+};
+
 enum RequestHeaderState
 {
     INVALID_HEADER = -1,

--- a/include/shell/HeaderAnalyzer.hpp
+++ b/include/shell/HeaderAnalyzer.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:54 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/11/23 19:50:49 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:05:16 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@ class HeaderAnalyzer
 {
 public:
     std::map<std::string, std::string> headers();
+    std::map<std::string, std::string> cookies() const;
     void set_method(RequestMethod method);
 
 public:
@@ -38,6 +39,7 @@ private:
     HeaderFieldValidator _validator;
     RequestHeaderState _state;
     std::map<std::string, std::string> _map;
+    std::map<std::string, std::string> _cookie_map;
     std::string _key;
     std::string _val;
 

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 19:45:12 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:05:30 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ class HeaderFieldValidator
 public:
     void set_method(RequestMethod method);
     void validate(std::map<std::string, std::string>& map);
+    std::map<std::string, std::string> get_cookie_map() const;
 
 public:
     HeaderFieldValidator();

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/11/30 21:38:09 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 18:30:28 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,7 @@ public:
 private:
     URIState _host_state;
     CacheState _cache_state;
+    CookieState _cookie_state;
     RequestMethod _method;
 
 private:
@@ -49,6 +50,12 @@ private:
     void _c_directive(unsigned char c);
     void _c_argument_start(unsigned char c);
     void _c_argument(unsigned char c);
+
+    void _validate_cookie(std::string& val);
+    void _cookie_ows(unsigned char c);
+    void _cookie_name(unsigned char c);
+    void _cookie_val(unsigned char c);
+    void _cookie_space(unsigned char c);
 };
 
 } // namespace webshell

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:05:30 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:28:53 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,7 @@ private:
     bool _is_unreserved(unsigned char c);
     bool _is_sub_delim(unsigned char c);
     bool _is_ows(unsigned char c);
+    bool _is_cookie_val(unsigned char c);
 
     void _validate_content_length(std::string& val);
     void _validate_cache_control(std::string& val);

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 18:30:28 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 19:45:12 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,10 @@ private:
     CookieState _cookie_state;
     RequestMethod _method;
 
+    std::string _name;
+    std::string _val;
+    std::map<std::string, std::string> _cookie_map;
+
 private:
     void _validate_host(std::string& val);
     void _feed_hostname(unsigned char c);
@@ -43,6 +47,7 @@ private:
     void _uri_port(unsigned char c);
     bool _is_unreserved(unsigned char c);
     bool _is_sub_delim(unsigned char c);
+    bool _is_ows(unsigned char c);
 
     void _validate_content_length(std::string& val);
     void _validate_cache_control(std::string& val);
@@ -52,7 +57,8 @@ private:
     void _c_argument(unsigned char c);
 
     void _validate_cookie(std::string& val);
-    void _cookie_ows(unsigned char c);
+    void _cookie_ows_start(unsigned char c);
+    void _cookie_ows_end(unsigned char c);
     void _cookie_name(unsigned char c);
     void _cookie_val(unsigned char c);
     void _cookie_space(unsigned char c);

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -53,6 +53,7 @@ private:
     Uri _uri;
     float _version;
     std::map<std::string, std::string> _headers;
+    std::map<std::string, std::string> _cookies;
     std::string* _read_buffer;
     webconfig::RequestConfig _config;
 

--- a/include/shell/Request.hpp
+++ b/include/shell/Request.hpp
@@ -21,10 +21,14 @@ public:
     float version() const;
     const webconfig::RequestConfig& config() const;
     const std::map<std::string, std::string>& headers() const;
+    const std::map<std::string, std::string>& cookies() const;
     const std::string& get_header(const std::string& name) const;
+    const std::string& get_cookie(const std::string& name) const;
     const std::string serialize() const;
     bool empty_buffer() const;
     bool has_header(const std::string& name) const;
+    bool has_cookie(const std::string& name) const;
+    bool has_cookies() const;
     bool read_chunked_body(std::vector<char>& chunked_body);
     void set_method(RequestMethod method);
     void set_uri(Uri uri);

--- a/include/shell/RequestAnalyzer.hpp
+++ b/include/shell/RequestAnalyzer.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 17:34:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/06 01:20:58 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:06:12 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,6 +45,7 @@ private:
     Uri _uri;
     float _version;
     std::map<std::string, std::string> _headers;
+    std::map<std::string, std::string> _cookies;
     std::string _body;
     Request _req;
 

--- a/source/shell/HeaderAnalyzer.cpp
+++ b/source/shell/HeaderAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:44 by mhuszar           #+#    #+#             */
-/*   Updated: 2024/11/30 21:52:50 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:09:13 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ HeaderAnalyzer::HeaderAnalyzer() /* : _connection_type(KEEP_ALIVE)*/
 }
 
 HeaderAnalyzer::HeaderAnalyzer(const HeaderAnalyzer& other) :
-    _state(other._state), _map(other._map), _key(other._key), _val(other._val)
+    _state(other._state), _map(other._map), _cookie_map(other._cookie_map), _key(other._key), _val(other._val)
 {
 }
 
@@ -34,6 +34,7 @@ HeaderAnalyzer& HeaderAnalyzer::operator=(const HeaderAnalyzer& other)
     if (this != &other) {
         _state = other._state;
         _map = other._map;
+        _cookie_map = other._cookie_map;
         _key = other._key;
         _val = other._val;
     }
@@ -267,6 +268,11 @@ void HeaderAnalyzer::_header_end_crlf(unsigned char c)
 std::map<std::string, std::string> HeaderAnalyzer::headers()
 {
     return (_map);
+}
+
+std::map<std::string, std::string> HeaderAnalyzer::cookies() const
+{
+    return (_cookie_map);
 }
 
 bool HeaderAnalyzer::done(void) const

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:10:31 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:29:37 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -239,8 +239,11 @@ void HeaderFieldValidator::_cookie_val(unsigned char c)
         else
             _cookie_state = CO_OWS_END;
     }
-    else //TODO: make cookie char validator fn here
+    else if (_is_cookie_val(c))
         _val.push_back(c);
+    else
+        throw utils::HttpException(webshell::BAD_REQUEST,
+            "Invalid character in cookie-val");
 }
 
 void HeaderFieldValidator::_cookie_space(unsigned char c)
@@ -430,6 +433,15 @@ bool HeaderFieldValidator::_is_ows(unsigned char c)
         return (true);
     }
     return (false);
+}
+
+bool HeaderFieldValidator::_is_cookie_val(unsigned char c)
+{
+    if ((c > 0 && c < 31) || c == 127 || c == '\"' || c == ','
+        || c == ';' || c == '\\') {
+        return (false);
+    }
+    return (true);
 }
 
 } // namespace webshell

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 19:51:10 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:10:31 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ HeaderFieldValidator::HeaderFieldValidator(const HeaderFieldValidator& other)
 {
     _host_state = other._host_state;
     _cookie_state = other._cookie_state;
+    _cookie_map = other._cookie_map;
 }
 
 HeaderFieldValidator&
@@ -39,6 +40,7 @@ HeaderFieldValidator::operator=(const HeaderFieldValidator& other)
     if (this != &other) {
         _host_state = other._host_state;
         _cookie_state = other._cookie_state;
+        _cookie_map = other._cookie_map;
     }
     return (*this);
 }
@@ -46,6 +48,11 @@ HeaderFieldValidator::operator=(const HeaderFieldValidator& other)
 void HeaderFieldValidator::set_method(RequestMethod method)
 {
     _method = method;
+}
+
+std::map<std::string, std::string> HeaderFieldValidator::get_cookie_map() const
+{
+    return (_cookie_map);
 }
 
 /*

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -28,6 +28,7 @@ Request::Request() :
     _uri(),
     _version(),
     _headers(),
+    _cookies(),
     _read_buffer()
 {
 }
@@ -40,6 +41,7 @@ Request::Request(std::string* buffer) :
     _uri(),
     _version(),
     _headers(),
+    _cookies(),
     _read_buffer(buffer)
 {
 }
@@ -52,6 +54,7 @@ Request::Request(const Request& other) :
     _uri(other._uri),
     _version(other._version),
     _headers(other._headers),
+    _cookies(other._cookies),
     _read_buffer(other._read_buffer),
     _config(other._config)
 {
@@ -67,6 +70,7 @@ Request& Request::operator=(const Request& other)
         _uri = other._uri;
         _version = other._version;
         _headers = other._headers;
+        _cookies = other._cookies;
         _read_buffer = other._read_buffer;
         _config = other._config;
     }

--- a/source/shell/Request.cpp
+++ b/source/shell/Request.cpp
@@ -104,6 +104,11 @@ const std::map<std::string, std::string>& Request::headers() const
     return (_headers);
 }
 
+const std::map<std::string, std::string>& Request::cookies() const
+{
+    return (_cookies);
+}
+
 const std::string& Request::get_header(const std::string& name) const
 {
     std::map<std::string, std::string>::const_iterator it = _headers.find(name);
@@ -114,9 +119,29 @@ const std::string& Request::get_header(const std::string& name) const
     return (it->second);
 }
 
+const std::string& Request::get_cookie(const std::string& name) const
+{
+    std::map<std::string, std::string>::const_iterator it = _cookies.find(name);
+
+    if (it == _cookies.end()) {
+        return (utils::EMPTY_STRING);
+    }
+    return (it->second);
+}
+
 bool Request::has_header(const std::string& name) const
 {
     return (_headers.find(name) != _headers.end());
+}
+
+bool Request::has_cookie(const std::string& name) const
+{
+    return (_headers.find(name) != _headers.end());
+}
+
+bool Request::has_cookies() const
+{
+    return (!_cookies.empty());
 }
 
 const std::string Request::serialize() const

--- a/source/shell/RequestAnalyzer.cpp
+++ b/source/shell/RequestAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 17:34:34 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/06 01:26:02 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/25 20:10:00 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,7 @@ RequestAnalyzer::RequestAnalyzer(const RequestAnalyzer& other) :
     _uri(other._uri),
     _version(other._version),
     _headers(other._headers),
+    _cookies(other._cookies),
     _body(other._body),
     _req(other._req)
 {
@@ -58,6 +59,7 @@ RequestAnalyzer& RequestAnalyzer::operator=(const RequestAnalyzer& other)
         _uri = other._uri;
         _version = other._version;
         _headers = other._headers;
+        _cookies = other._cookies;
         _body = other._body;
         _req = other._req;
     }
@@ -82,6 +84,7 @@ void RequestAnalyzer::feed(const char ch)
         _header_analyzer.feed(ch);
         if (_header_analyzer.done()) {
             _headers = _header_analyzer.headers();
+            _cookies = _header_analyzer.cookies();
             _assemble_request();
             _state = COMPLETE;
         }


### PR DESCRIPTION
Did it so you can implement this feature @LeaYeh but pls check if it works cause i didn't test it yet.
`Request` class (I know...) should contain a map named `_cookie` containing all `cookie-name` as key and `cookie-value` as value (from RFC 6265). I have added these functions:
- `cookies()` should get you the whole map
- `get_cookie(std::string)` gets you a val for key as argument
- `has_cookie(std::string)` is a bool and returns true if key is in the map
- `has_cookies()` is a bool and returns true if cookie map is not empty

Pls test and tell if you need anything else