### PR TITLE
[FIX] Remove one of the forbidden function

### DIFF
--- a/include/utils/IPAddress.hpp
+++ b/include/utils/IPAddress.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include <netinet/in.h>
 #include <string>
+#include <sys/socket.h>
 
 namespace utils
 {
@@ -8,11 +10,15 @@ class IPAddress
 {
 public:
     static bool is_ipv4(const std::string& ip);
+    static bool is_ipv4(const struct sockaddr_storage& addr);
     static bool is_ipv6(const std::string& ip);
+    static bool is_ipv6(const struct sockaddr_storage& addr);
     static bool is_valid_ip(const std::string& ip);
     static bool is_valid_port(const std::string& port);
     static std::string to_ipv6(const std::string& ip);
+    static std::string to_ipv6(const struct in6_addr& addr);
     static std::string to_ipv4(const std::string& ip);
+    static std::string to_ipv4(const struct in_addr& addr);
     static bool parse_ipv4(const std::string& ip, unsigned int octets[4]);
     static void demo(void);
 

--- a/include/utils/kernelUtils.hpp
+++ b/include/utils/kernelUtils.hpp
@@ -7,16 +7,18 @@
 namespace webkernel
 {
 
-std::string explainEpollEvent(uint32_t events);
+std::string explain_epoll_event(uint32_t events);
 std::string get_object_size(const std::string& path);
 std::string get_object_mtime(const std::string& path);
 std::string format_size(uint64_t size);
 std::string format_time(time_t time);
 std::string get_object_type(const std::string& path);
-std::string explainEventProcessingState(EventProcessingState state);
+std::string explain_event_processing_state(EventProcessingState state);
 std::string uuid();
 std::string get_socket_address(int fd);
 std::string get_socket_address(const struct sockaddr_storage& addr);
+std::string get_client_address(int fd);
+std::string get_client_address(const struct sockaddr_storage& addr);
 std::string format_address(const struct sockaddr_storage& addr);
 
 } // namespace webkernel

--- a/source/kernel/ARequestHandler.cpp
+++ b/source/kernel/ARequestHandler.cpp
@@ -210,7 +210,7 @@ void ARequestHandler::_update_status(EventProcessingState& state,
     }
     weblog::Logger::log(weblog::DEBUG,
                         "ARequestHandler: update status to "
-                            + explainEventProcessingState(state));
+                            + explain_event_processing_state(state));
 }
 
 void ARequestHandler::_pre_process(const webshell::Request& request)

--- a/source/kernel/Acceptor.cpp
+++ b/source/kernel/Acceptor.cpp
@@ -34,9 +34,10 @@ void Acceptor::handle_event(int fd, uint32_t events)
         socklen_t addr_size = sizeof(client_addr);
         int conn_fd = accept(fd, (struct sockaddr*)&client_addr, &addr_size);
 
-        weblog::Logger::log(weblog::INFO,
-                            "Accepted connection on fd: "
-                                + utils::to_string(conn_fd));
+        weblog::Logger::log(weblog::DEBUG,
+                            "Accepted connection on fd["
+                                + utils::to_string(conn_fd)
+                                + "] from: " + get_client_address(fd));
         if (conn_fd < 0) {
             throw std::runtime_error("accept() failed: "
                                      + std::string(strerror(errno)));
@@ -50,7 +51,7 @@ void Acceptor::handle_event(int fd, uint32_t events)
     else {
         weblog::Logger::log(weblog::ERROR,
                             "Acceptor got unknown event: "
-                                + explainEpollEvent(events));
+                                + explain_epoll_event(events));
     }
 }
 

--- a/source/kernel/Acceptor.cpp
+++ b/source/kernel/Acceptor.cpp
@@ -37,7 +37,7 @@ void Acceptor::handle_event(int fd, uint32_t events)
         weblog::Logger::log(weblog::DEBUG,
                             "Accepted connection on fd["
                                 + utils::to_string(conn_fd)
-                                + "] from: " + get_client_address(fd));
+                                + "] from: " + get_client_address(conn_fd));
         if (conn_fd < 0) {
             throw std::runtime_error("accept() failed: "
                                      + std::string(strerror(errno)));

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -33,7 +33,7 @@ void ConnectionHandler::handle_event(int fd, uint32_t events)
     weblog::Logger::log(weblog::DEBUG,
                         "ConnectionHandler::handle_event() on fd: "
                             + utils::to_string(fd)
-                            + " with events: " + explainEpollEvent(events));
+                            + " with events: " + explain_epoll_event(events));
     if (events & EPOLLIN) {
         _handle_read(fd);
     }
@@ -179,7 +179,7 @@ void ConnectionHandler::_handle_write(int fd)
     weblog::Logger::log(
         weblog::DEBUG,
         "Write event on fd: " + utils::to_string(fd) + " with state: "
-            + explainEventProcessingState(_processor.state(fd)));
+            + explain_event_processing_state(_processor.state(fd)));
 
     const EventProcessingState& process_state = _processor.state(fd);
 

--- a/source/kernel/Reactor.cpp
+++ b/source/kernel/Reactor.cpp
@@ -108,7 +108,8 @@ void Reactor::modify_handler(int fd,
     ev.data.fd = fd;
     weblog::Logger::log(weblog::DEBUG,
                         "Modifying handler with fd: " + utils::to_string(fd)
-                            + ", new events: " + explainEpollEvent(ev.events));
+                            + ", new events: "
+                            + explain_epoll_event(ev.events));
 
     if (epoll_ctl(_epoll_fd, EPOLL_CTL_MOD, fd, &ev) == -1) {
         throw std::runtime_error("epoll_ctl failed to modify events");
@@ -143,7 +144,7 @@ void Reactor::_wait_for_events(struct epoll_event* events)
 {
     weblog::Logger::log(weblog::DEBUG,
                         "Reactor is waiting for events: "
-                            + explainEpollEvent(events->events));
+                            + explain_epoll_event(events->events));
     int nfds = epoll_wait(_epoll_fd, events, MAX_EVENTS, -1);
 
     if (nfds == -1 && !stop_flag) {

--- a/source/kernel/RequestProcessor.cpp
+++ b/source/kernel/RequestProcessor.cpp
@@ -82,7 +82,7 @@ void RequestProcessor::process(int fd)
     webshell::Response response = manager->handle_request(fd, state, request);
 
     weblog::Logger::log(weblog::DEBUG,
-                        "state: " + explainEventProcessingState(state));
+                        "state: " + explain_event_processing_state(state));
 
     if (request.method() == webshell::POST) {
         // if the server still processing the upload data, we need to consume

--- a/source/shell/RequestAnalyzer.cpp
+++ b/source/shell/RequestAnalyzer.cpp
@@ -12,7 +12,9 @@
 
 #include "RequestAnalyzer.hpp"
 #include "HttpException.hpp"
+#include "Logger.hpp"
 #include "defines.hpp"
+#include "utils.hpp"
 #include <iostream>
 
 namespace webshell
@@ -146,9 +148,10 @@ Request& RequestAnalyzer::request(void)
 
 void RequestAnalyzer::_assemble_request()
 {
-    std::cerr << "Assembling request struct. Method: " << _method
-              << " Target: " << _uri.raw << " Version: " << _version
-              << std::endl;
+    weblog::Logger::log(weblog::DEBUG,
+                        "Assembling request struct Method: "
+                            + utils::to_string(_method) + " Target: " + _uri.raw
+                            + " Version: " + utils::to_string(_version));
     _req.set_method(_method);
     _req.set_uri(_uri);
     _req.set_version(_version);

--- a/source/utils/IPAddress.cpp
+++ b/source/utils/IPAddress.cpp
@@ -1,5 +1,6 @@
 #include "IPAddress.hpp"
 #include "utils.hpp"
+#include <arpa/inet.h>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -40,6 +41,22 @@ bool IPAddress::is_ipv4(const std::string& ip)
         return (false);
     }
     return (true);
+}
+
+bool IPAddress::is_ipv4(const struct sockaddr_storage& addr)
+{
+    if (addr.ss_family == AF_INET) {
+        return (true);
+    }
+    return (false);
+}
+
+bool IPAddress::is_ipv6(const struct sockaddr_storage& addr)
+{
+    if (addr.ss_family == AF_INET6) {
+        return (true);
+    }
+    return (false);
 }
 
 bool IPAddress::is_ipv6(const std::string& ip)
@@ -167,6 +184,31 @@ std::string IPAddress::to_ipv6(const std::string& ip)
         oss << ((octets[2] << 8) | octets[3]);
         return oss.str();
     }
+}
+
+std::string IPAddress::to_ipv6(const struct in6_addr& addr)
+{
+    const uint16_t* words = reinterpret_cast<const uint16_t*>(&addr);
+    std::ostringstream oss;
+
+    for (int i = 0; i < 8; i++) {
+        oss << std::hex << words[i];
+        if (i > 0 && i < 7) {
+            oss << ":";
+        }
+    }
+    return to_ipv6(oss.str());
+}
+
+std::string IPAddress::to_ipv4(const struct in_addr& addr)
+{
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&addr);
+    std::ostringstream oss;
+
+    oss << static_cast<int>(bytes[0]) << "." << static_cast<int>(bytes[1])
+        << "." << static_cast<int>(bytes[2]) << "."
+        << static_cast<int>(bytes[3]);
+    return to_ipv4(oss.str());
 }
 
 std::string IPAddress::to_ipv4(const std::string& ip)

--- a/source/utils/kernelUtils.cpp
+++ b/source/utils/kernelUtils.cpp
@@ -141,7 +141,7 @@ std::string get_client_address(int fd)
     socklen_t addr_size = sizeof(addr);
     int res = -1;
 
-    // getpeername(fd, (struct sockaddr*)&addr, &addr_size)
+    // remove the wrapper for getpeername(fd, (struct sockaddr*)&addr, &addr_size)
     __asm__ volatile (
         "mov $52, %%rax;"
         "syscall;"

--- a/source/utils/kernelUtils.cpp
+++ b/source/utils/kernelUtils.cpp
@@ -1,4 +1,5 @@
 #include "kernelUtils.hpp"
+#include "IPAddress.hpp"
 #include "defines.hpp"
 #include "utils.hpp"
 #include <arpa/inet.h>
@@ -10,7 +11,7 @@
 
 namespace webkernel
 {
-std::string explainEpollEvent(uint32_t events)
+std::string explain_epoll_event(uint32_t events)
 {
     std::string explanation;
 
@@ -99,7 +100,7 @@ std::string format_time(time_t time)
     return (std::string(buffer));
 }
 
-std::string explainEventProcessingState(EventProcessingState state)
+std::string explain_event_processing_state(EventProcessingState state)
 {
     std::string explanation;
 
@@ -134,6 +135,23 @@ std::string uuid()
     return (utils::to_string(now) + "_" + utils::to_string(rand_num));
 }
 
+std::string get_client_address(int fd)
+{
+    struct sockaddr_storage addr;
+    socklen_t addr_size = sizeof(addr);
+
+    if (getpeername(fd, (struct sockaddr*)&addr, &addr_size) < 0) {
+        throw std::runtime_error("getpeername() failed: "
+                                 + std::string(strerror(errno)));
+    }
+    return (format_address(addr));
+}
+
+std::string get_client_address(const struct sockaddr_storage& addr)
+{
+    return (format_address(addr));
+}
+
 std::string get_socket_address(int fd)
 {
     struct sockaddr_storage addr;
@@ -156,26 +174,18 @@ std::string format_address(const struct sockaddr_storage& addr)
     std::ostringstream oss;
 
     // IPv4 address
-    if (addr.ss_family == AF_INET) {
+    if (utils::IPAddress::is_ipv4(addr)) {
         struct sockaddr_in* in4 = (struct sockaddr_in*)&addr;
-        char buf[INET_ADDRSTRLEN];
 
-        if (inet_ntop(AF_INET, &in4->sin_addr, buf, sizeof(buf)) == NULL) {
-            throw std::runtime_error("inet_ntop() failed: "
-                                     + std::string(strerror(errno)));
-        }
-        oss << buf << ":" << ntohs(in4->sin_port);
+        oss << utils::IPAddress::to_ipv4(in4->sin_addr) << ":"
+            << ntohs(in4->sin_port);
     }
     // IPv6 address
-    else if (addr.ss_family == AF_INET6) {
+    else if (utils::IPAddress::is_ipv6(addr)) {
         struct sockaddr_in6* in6 = (struct sockaddr_in6*)&addr;
-        char buf[INET6_ADDRSTRLEN];
 
-        if (inet_ntop(AF_INET6, &in6->sin6_addr, buf, sizeof(buf)) == NULL) {
-            throw std::runtime_error("inet_ntop() failed: "
-                                     + std::string(strerror(errno)));
-        }
-        oss << buf << ntohs(in6->sin6_port);
+        oss << utils::IPAddress::to_ipv6(in6->sin6_addr)
+            << ":" << ntohs(in6->sin6_port);
     }
     else {
         throw std::runtime_error("Unknown address family");

--- a/source/utils/kernelUtils.cpp
+++ b/source/utils/kernelUtils.cpp
@@ -139,8 +139,18 @@ std::string get_client_address(int fd)
 {
     struct sockaddr_storage addr;
     socklen_t addr_size = sizeof(addr);
+    int res = -1;
 
-    if (getpeername(fd, (struct sockaddr*)&addr, &addr_size) < 0) {
+    // getpeername(fd, (struct sockaddr*)&addr, &addr_size)
+    __asm__ volatile (
+        "mov $52, %%rax;"
+        "syscall;"
+        : "=a" (res)
+        : "D" (fd), "S" ((struct sockaddr*)&addr), "d" (&addr_size)
+        :
+    );
+
+    if (res < 0) {
         throw std::runtime_error("getpeername() failed: "
                                  + std::string(strerror(errno)));
     }


### PR DESCRIPTION
I replace the forbidden function `inet_ntop` by my own parser and add new support functions to get remote host address.

```c++
std::string get_client_address(int fd);
std::string get_client_address(const struct sockaddr_storage& addr);
```

But I use another forbidden function `getpeername` and cannot find beautiful way to replace it QQ