### PR TITLE
[REFACTOR] Add base class for parser classes

### DIFF
--- a/include/kernel/Kernel.hpp
+++ b/include/kernel/Kernel.hpp
@@ -20,7 +20,7 @@ public:
 
 private:
     Acceptor* _acceptor;
-    SessionManager* _session_manager;
+    // SessionManager* _session_manager;
 
     void _register_listener(void);
     int _create_listen_socket(const char* ip, const char* port);

--- a/include/shell/AParser.hpp
+++ b/include/shell/AParser.hpp
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   AParser.hpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/27 17:21:54 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/01/27 17:38:20 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#pragma once
+
+namespace webshell
+{
+
+class AParser
+{
+public:
+
+protected:
+    AParser();
+    virtual ~AParser();
+    AParser(const AParser& other);
+    AParser& operator=(const AParser& other);
+
+protected:
+    bool _is_unreserved(unsigned char c);
+    bool _is_gen_delim(unsigned char c);
+    bool _is_sub_delim(unsigned char c);
+    bool _is_ows(unsigned char c);
+    bool _is_tchar(unsigned char c);
+    bool _is_vchar(unsigned char c);
+    bool _is_pchar(unsigned char c);
+    unsigned char _lowcase(unsigned char c);
+    bool _is_query_or_fragment_part(unsigned char c);
+    bool _is_cookie_val(unsigned char c);
+};
+
+} // namespace webshell

--- a/include/shell/HeaderAnalyzer.hpp
+++ b/include/shell/HeaderAnalyzer.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:54 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:35:22 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:49:23 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,32 +53,6 @@ private:
     void _field_end_crlf(unsigned char c);
     void _check_obs_fold(unsigned char c);
     void _header_end_crlf(unsigned char c);
-    // bool _is_ows(unsigned char c);
-    // bool _is_vchar(unsigned char c);
-    // unsigned char _lowcase(unsigned char c);
-
-    // TO_DO: Seperate the variables name with prefix by different usage?
-    // std::string _host;
-    // std::string _header_new_line;
-    // std::string _host_name;
-    // std::string _accept;
-    // std::string _accept_type;
-    // std::string _accept_encoding;
-    // std::string _accept_encoding_type;
-    // std::string _connection;
-    // ConnectionType _connection_type;
-    // std::string _content_type;
-    // std::string _content_type_name;
-    // std::string _content_length;
-    // std::string _content_length_nbr;
-    // std::string _invalid_header;
-    // std::string _the_rest;
-    // std::string host() const;
-    // std::string accept() const;
-    // std::string accept_encoding() const;
-    // std::string connection() const;
-    // ConnectionType connection_type() const;
-    // std::string content_length() const;
 };
 
 } // namespace webshell

--- a/include/shell/HeaderAnalyzer.hpp
+++ b/include/shell/HeaderAnalyzer.hpp
@@ -6,18 +6,19 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:54 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:05:16 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:35:22 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
+#include "AParser.hpp"
 #include "HeaderFieldValidator.hpp"
 #include "defines.hpp"
 #include <map>
 
 namespace webshell
 {
-class HeaderAnalyzer
+class HeaderAnalyzer : public AParser
 {
 public:
     std::map<std::string, std::string> headers();
@@ -52,9 +53,9 @@ private:
     void _field_end_crlf(unsigned char c);
     void _check_obs_fold(unsigned char c);
     void _header_end_crlf(unsigned char c);
-    bool _is_ows(unsigned char c);
-    bool _is_vchar(unsigned char c);
-    unsigned char _lowcase(unsigned char c);
+    // bool _is_ows(unsigned char c);
+    // bool _is_vchar(unsigned char c);
+    // unsigned char _lowcase(unsigned char c);
 
     // TO_DO: Seperate the variables name with prefix by different usage?
     // std::string _host;

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:45:26 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:48:12 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,9 +47,6 @@ private:
     void _feed_hostname(unsigned char c);
     void _uri_host_regname(unsigned char c);
     void _uri_port(unsigned char c);
-    // bool _is_unreserved(unsigned char c);
-    // bool _is_sub_delim(unsigned char c);
-    // bool _is_ows(unsigned char c);
 
     void _validate_content_length(std::string& val);
     void _validate_cache_control(std::string& val);

--- a/include/shell/HeaderFieldValidator.hpp
+++ b/include/shell/HeaderFieldValidator.hpp
@@ -6,11 +6,12 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:35:36 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:28:53 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:45:26 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
+#include "AParser.hpp"
 #include "defines.hpp"
 #include <map>
 #include <string>
@@ -18,7 +19,7 @@
 namespace webshell
 {
 
-class HeaderFieldValidator
+class HeaderFieldValidator : public AParser
 {
 public:
     void set_method(RequestMethod method);
@@ -46,10 +47,9 @@ private:
     void _feed_hostname(unsigned char c);
     void _uri_host_regname(unsigned char c);
     void _uri_port(unsigned char c);
-    bool _is_unreserved(unsigned char c);
-    bool _is_sub_delim(unsigned char c);
-    bool _is_ows(unsigned char c);
-    bool _is_cookie_val(unsigned char c);
+    // bool _is_unreserved(unsigned char c);
+    // bool _is_sub_delim(unsigned char c);
+    // bool _is_ows(unsigned char c);
 
     void _validate_content_length(std::string& val);
     void _validate_cache_control(std::string& val);

--- a/include/shell/RequestLineAnalyzer.hpp
+++ b/include/shell/RequestLineAnalyzer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AParser.hpp"
 #include "Uri.hpp"
 #include "UriAnalyzer.hpp"
 #include "defines.hpp"
@@ -8,7 +9,7 @@
 namespace webshell
 {
 
-class RequestLineAnalyzer
+class RequestLineAnalyzer : public AParser
 {
 public:
     RequestMethod method(void) const;

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AParser.hpp"
 #include "Uri.hpp"
 #include "defines.hpp"
 #include <string>
@@ -7,7 +8,7 @@
 namespace webshell
 {
 
-class UriAnalyzer
+class UriAnalyzer : public AParser
 {
 public:
     void parse_uri(std::string& uri);
@@ -51,11 +52,11 @@ private:
     void _uri_query(unsigned char c);
     void _uri_fragment(unsigned char c);
 
-    bool _is_gen_delim(unsigned char c);
-    bool _is_sub_delim(unsigned char c);
-    bool _is_unreserved(unsigned char c);
-    bool _is_pchar(unsigned char c);
-    bool _is_query_or_fragment_part(unsigned char c);
+    // bool _is_gen_delim(unsigned char c);
+    // bool _is_sub_delim(unsigned char c);
+    // bool _is_unreserved(unsigned char c);
+    // bool _is_pchar(unsigned char c);
+    // bool _is_query_or_fragment_part(unsigned char c);
 
     unsigned char _decode_percent(std::string& str);
     unsigned char _decode_num_and_alpha();
@@ -63,7 +64,7 @@ private:
     void _percent_decode_all();
     unsigned char _hexval(unsigned char c);
     bool _valid_hexdigit(unsigned char c);
-    unsigned char _lowcase(unsigned char c);
+    // unsigned char _lowcase(unsigned char c);
 
     std::string _remove_dot_segments() const;
     void _remove_last_segment(std::string& str) const;

--- a/include/shell/UriAnalyzer.hpp
+++ b/include/shell/UriAnalyzer.hpp
@@ -52,19 +52,12 @@ private:
     void _uri_query(unsigned char c);
     void _uri_fragment(unsigned char c);
 
-    // bool _is_gen_delim(unsigned char c);
-    // bool _is_sub_delim(unsigned char c);
-    // bool _is_unreserved(unsigned char c);
-    // bool _is_pchar(unsigned char c);
-    // bool _is_query_or_fragment_part(unsigned char c);
-
     unsigned char _decode_percent(std::string& str);
     unsigned char _decode_num_and_alpha();
     void _decode(std::string& str);
     void _percent_decode_all();
     unsigned char _hexval(unsigned char c);
     bool _valid_hexdigit(unsigned char c);
-    // unsigned char _lowcase(unsigned char c);
 
     std::string _remove_dot_segments() const;
     void _remove_last_segment(std::string& str) const;

--- a/include/utils/utils.hpp
+++ b/include/utils/utils.hpp
@@ -22,7 +22,7 @@ size_t convert_to_size(const std::string& str);
 std::vector<std::string> split(const std::string& str, char delim);
 bool is_directory(const std::string& path);
 bool is_file(const std::string& path);
-bool is_tchar(unsigned char c);
+// bool is_tchar(unsigned char c);
 bool start_with(const std::string& str, const std::string& prefix);
 std::string basefolder(const std::string& path);
 std::string basename(const std::string& path);

--- a/source/shell/AParser.cpp
+++ b/source/shell/AParser.cpp
@@ -1,0 +1,154 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   AParser.cpp                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/27 17:30:25 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/01/27 17:44:26 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "AParser.hpp"
+#include <cctype>
+
+namespace webshell
+{
+
+AParser::AParser()
+{
+    
+}
+AParser::~AParser()
+{
+    
+}
+AParser::AParser(const AParser& other)
+{
+    (void)other;
+}
+AParser& AParser::operator=(const AParser& other)
+{
+    (void)other;
+    return *this;
+}
+
+unsigned char AParser::_lowcase(unsigned char c)
+{
+    if (c >= 'A' && c <= 'Z') {
+        return (c += 32);
+    }
+    return (c);
+}
+
+bool AParser::_is_unreserved(unsigned char c)
+{
+    if (isalpha(c)) {
+        return (true);
+    }
+    if (isdigit(c)) {
+        return (true);
+    }
+    if (c == '-' || c == '.' || c == '_' || c == '~') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_sub_delim(unsigned char c)
+{
+    if (c == '!' || c == '$' || c == '&' || c == '\'') {
+        return (true);
+    }
+    if (c == '(' || c == ')' || c == '*' || c == '+') {
+        return (true);
+    }
+    if (c == ',' || c == ';' || c == '=') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_gen_delim(unsigned char c)
+{
+    if (c == ':' || c == '/' || c == '?' || c == '#') {
+        return (true);
+    }
+    if (c == '[' || c == ']' || c == '@') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_pchar(unsigned char c)
+{
+    if (_is_unreserved(c)) {
+        return (true);
+    }
+    if (_is_sub_delim(c)) {
+        return (true);
+    }
+    if (c == ':') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_query_or_fragment_part(unsigned char c)
+{
+    if (_is_pchar(c)) {
+        return (true);
+    }
+    if (c == '/' || c == '?') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_tchar(unsigned char c)
+{
+    if (isdigit(c) || isalpha(c)) {
+        return (true);
+    }
+    if (c == '!' || c == '#' || c == '$' || c == '%') {
+        return (true);
+    }
+    if (c == '&' || c == '`' || c == '*' || c == '+') {
+        return (true);
+    }
+    if (c == '-' || c == '.' || c == '^' || c == '_') {
+        return (true);
+    }
+    if (c == '|' || c == '~' || c == '\'') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_ows(unsigned char c)
+{
+    if (c == ' ' || c == '\t') {
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_vchar(unsigned char c)
+{
+    if (c > 32 && c < 127) { // 32 is technically printable but its part of ows
+        return (true);
+    }
+    return (false);
+}
+
+bool AParser::_is_cookie_val(unsigned char c)
+{
+    if ((c > 0 && c < 31) || c == 127 || c == '\"' || c == ','
+        || c == ';' || c == '\\') {
+        return (false);
+    }
+    return (true);
+}
+    
+}

--- a/source/shell/HeaderAnalyzer.cpp
+++ b/source/shell/HeaderAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:44 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:09:13 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:36:03 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,33 +88,17 @@ void HeaderAnalyzer::set_method(RequestMethod method)
     _validator.set_method(method);
 }
 
-bool HeaderAnalyzer::_is_ows(unsigned char c)
-{
-    if (c == ' ' || c == '\t') {
-        return (true);
-    }
-    return (false);
-}
-
-unsigned char HeaderAnalyzer::_lowcase(unsigned char c)
-{
-    if (c >= 'A' && c <= 'Z') {
-        return (c += 32);
-    }
-    return (c);
-}
-
-bool HeaderAnalyzer::_is_vchar(unsigned char c)
-{
-    if (c > 32 && c < 127) { // 32 is technically printable but its part of ows
-        return (true);
-    }
-    return (false);
-}
+// unsigned char HeaderAnalyzer::_lowcase(unsigned char c)
+// {
+//     if (c >= 'A' && c <= 'Z') {
+//         return (c += 32);
+//     }
+//     return (c);
+// }
 
 void HeaderAnalyzer::_start_header(unsigned char c)
 {
-    if (utils::is_tchar(c)) {
+    if (_is_tchar(c)) {
         _key.push_back(_lowcase(c));
         _state = FIELD_NAME;
     }
@@ -128,7 +112,7 @@ void HeaderAnalyzer::_start_header(unsigned char c)
 
 void HeaderAnalyzer::_field_name(unsigned char c)
 {
-    if (utils::is_tchar(c)) {
+    if (_is_tchar(c)) {
         _key.push_back(_lowcase(c));
     }
     else if (c == ':') {
@@ -235,7 +219,7 @@ void HeaderAnalyzer::_field_end_crlf(unsigned char c)
 
 void HeaderAnalyzer::_check_obs_fold(unsigned char c)
 {
-    if (utils::is_tchar(c)) {
+    if (_is_tchar(c)) {
         _key.push_back(_lowcase(c));
         _state = FIELD_NAME;
     }

--- a/source/shell/HeaderAnalyzer.cpp
+++ b/source/shell/HeaderAnalyzer.cpp
@@ -6,13 +6,13 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:44 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:36:03 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:53:50 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "HeaderAnalyzer.hpp"
 #include "HttpException.hpp"
-#include "utils.hpp"
+#include <stdexcept>
 
 namespace webshell
 {
@@ -87,14 +87,6 @@ void HeaderAnalyzer::set_method(RequestMethod method)
 {
     _validator.set_method(method);
 }
-
-// unsigned char HeaderAnalyzer::_lowcase(unsigned char c)
-// {
-//     if (c >= 'A' && c <= 'Z') {
-//         return (c += 32);
-//     }
-//     return (c);
-// }
 
 void HeaderAnalyzer::_start_header(unsigned char c)
 {

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:42:10 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:50:20 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -360,7 +360,7 @@ void HeaderFieldValidator::_feed_hostname(unsigned char c)
     case URI_HOST_REGNAME:
         _uri_host_regname(c);
         break;
-    // TODO: can (should) we do IPV4 as well?
+    // TODO: can (should) we do IPV6 as well?
     case URI_PORT:
         _uri_port(c);
         break;

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,14 +6,13 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/25 20:29:37 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:42:10 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "HeaderFieldValidator.hpp"
 #include "HttpException.hpp"
 #include "defines.hpp"
-#include "utils.hpp"
 #include <cctype>
 #include <cstddef>
 #include <stdexcept>
@@ -199,7 +198,7 @@ void HeaderFieldValidator::_validate_cookie(std::string& val)
 
 void HeaderFieldValidator::_cookie_ows_start(unsigned char c)
 {
-    if (utils::is_tchar(c))
+    if (_is_tchar(c))
     {
         _name.push_back(c);
         _cookie_state = CO_NAME;
@@ -220,7 +219,7 @@ void HeaderFieldValidator::_cookie_name(unsigned char c)
 {
     if (c == '=')
         _cookie_state = CO_VALUE;
-    else if (utils::is_tchar(c))
+    else if (_is_tchar(c))
         _name.push_back(c);
     else
         throw utils::HttpException(webshell::BAD_REQUEST,
@@ -289,7 +288,7 @@ void HeaderFieldValidator::_validate_cache_control(std::string& val)
 
 void HeaderFieldValidator::_c_start(unsigned char c)
 {
-    if (utils::is_tchar(c)) {
+    if (_is_tchar(c)) {
         _cache_state = C_DIRECTIVE;
     }
     else {
@@ -307,7 +306,7 @@ void HeaderFieldValidator::_c_directive(unsigned char c)
     else if (c == ',') {
         _cache_state = C_DIRECTIVE_START;
     }
-    else if (utils::is_tchar(c)) {
+    else if (_is_tchar(c)) {
         return;
     }
     else {
@@ -396,52 +395,6 @@ void HeaderFieldValidator::_uri_port(unsigned char c)
             webshell::BAD_REQUEST,
             "Bad configuration of hostname port field value");
     }
-}
-
-// TODO: move the following 2 to utils. Duplicate version exists in UriAnalyzer.
-bool HeaderFieldValidator::_is_unreserved(unsigned char c)
-{
-    if (isalpha(c)) {
-        return (true);
-    }
-    if (isdigit(c)) {
-        return (true);
-    }
-    if (c == '-' || c == '.' || c == '_' || c == '~') {
-        return (true);
-    }
-    return (false);
-}
-
-bool HeaderFieldValidator::_is_sub_delim(unsigned char c)
-{
-    if (c == '!' || c == '$' || c == '&' || c == '\'') {
-        return (true);
-    }
-    if (c == '(' || c == ')' || c == '*' || c == '+') {
-        return (true);
-    }
-    if (c == ',' || c == ';' || c == '=') {
-        return (true);
-    }
-    return (false);
-}
-
-bool HeaderFieldValidator::_is_ows(unsigned char c)
-{
-    if (c == ' ' || c == '\t') {
-        return (true);
-    }
-    return (false);
-}
-
-bool HeaderFieldValidator::_is_cookie_val(unsigned char c)
-{
-    if ((c > 0 && c < 31) || c == 127 || c == '\"' || c == ','
-        || c == ';' || c == '\\') {
-        return (false);
-    }
-    return (true);
 }
 
 } // namespace webshell

--- a/source/shell/RequestLineAnalyzer.cpp
+++ b/source/shell/RequestLineAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 16:52:31 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/06 01:22:54 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:34:55 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -118,7 +118,7 @@ void RequestLineAnalyzer::_validate_start(unsigned char c)
     if (c == '\r') {
         _state = PRE_LF;
     }
-    else if (!utils::is_tchar(c)) {
+    else if (!_is_tchar(c)) {
         throw utils::HttpException(webshell::BAD_REQUEST,
                                    "RLAnalyzer failed at validate start");
     }
@@ -144,7 +144,7 @@ void RequestLineAnalyzer::_analyze_method(unsigned char c)
     if (c == ' ') {
         _state = URI;
     }
-    else if (!utils::is_tchar(c)) {
+    else if (!_is_tchar(c)) {
         throw utils::HttpException(webshell::BAD_REQUEST,
                                    "error at check method");
     }

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/06 01:32:34 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:32:35 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -520,14 +520,6 @@ bool UriAnalyzer::_valid_hexdigit(unsigned char c)
     return (false);
 }
 
-unsigned char UriAnalyzer::_lowcase(unsigned char c)
-{
-    if (c >= 'A' && c <= 'Z') {
-        return (c += 32);
-    }
-    return (c);
-}
-
 unsigned char UriAnalyzer::_hexval(unsigned char c)
 {
     if (isdigit(c)) {
@@ -537,72 +529,6 @@ unsigned char UriAnalyzer::_hexval(unsigned char c)
         return (c - 'a' + 10);
     }
     return (c - 'A' + 10);
-}
-
-// TODO: move the following 2 to utils. Duplicate version exists in
-// HeaderFieldValidator.
-bool UriAnalyzer::_is_unreserved(unsigned char c)
-{
-    if (isalpha(c)) {
-        return (true);
-    }
-    if (isdigit(c)) {
-        return (true);
-    }
-    if (c == '-' || c == '.' || c == '_' || c == '~') {
-        return (true);
-    }
-    return (false);
-}
-
-bool UriAnalyzer::_is_sub_delim(unsigned char c)
-{
-    if (c == '!' || c == '$' || c == '&' || c == '\'') {
-        return (true);
-    }
-    if (c == '(' || c == ')' || c == '*' || c == '+') {
-        return (true);
-    }
-    if (c == ',' || c == ';' || c == '=') {
-        return (true);
-    }
-    return (false);
-}
-
-bool UriAnalyzer::_is_gen_delim(unsigned char c)
-{
-    if (c == ':' || c == '/' || c == '?' || c == '#') {
-        return (true);
-    }
-    if (c == '[' || c == ']' || c == '@') {
-        return (true);
-    }
-    return (false);
-}
-
-bool UriAnalyzer::_is_pchar(unsigned char c)
-{
-    if (_is_unreserved(c)) {
-        return (true);
-    }
-    if (_is_sub_delim(c)) {
-        return (true);
-    }
-    if (c == ':') {
-        return (true);
-    }
-    return (false);
-}
-
-bool UriAnalyzer::_is_query_or_fragment_part(unsigned char c)
-{
-    if (_is_pchar(c)) {
-        return (true);
-    }
-    if (c == '/' || c == '?') {
-        return (true);
-    }
-    return (false);
 }
 
 } // namespace webshell

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:32:35 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/01/27 17:49:33 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -179,7 +179,6 @@ Uri UriAnalyzer::take_uri() const
 {
     Uri ret;
     ret.raw = _uri;
-    // ret.scheme = "http://";
     ret.authority = _host + ":" + _port;
     ret.host = _host;
     ret.port = _port;

--- a/source/utils/utils.cpp
+++ b/source/utils/utils.cpp
@@ -17,26 +17,6 @@ bool safe_close(int& fd)
     return (true);
 }
 
-bool is_tchar(unsigned char c)
-{
-    if (isdigit(c) || isalpha(c)) {
-        return (true);
-    }
-    if (c == '!' || c == '#' || c == '$' || c == '%') {
-        return (true);
-    }
-    if (c == '&' || c == '`' || c == '*' || c == '+') {
-        return (true);
-    }
-    if (c == '-' || c == '.' || c == '^' || c == '_') {
-        return (true);
-    }
-    if (c == '|' || c == '~' || c == '\'') {
-        return (true);
-    }
-    return (false);
-}
-
 bool is_directory(const std::string& path)
 {
     struct stat file_stat;


### PR DESCRIPTION
Ideally this should not change any functionality.

There has been a lot of small shared utils functions that I made from RFC definitions like `is_tchar` that either existed in duplicate versions in multiple parser classes or were exported to `utils` and used as a global. I thought it was getting out of hand and inheritance is a nicer way to handle it.

I am not a master of design so this is why I got into this situation in the first place.