### PR TITLE
[FEAT] Add unwind classes

### DIFF
--- a/cgi-bin/loop.sh
+++ b/cgi-bin/loop.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+while true
+do
+  sleep 1
+done

--- a/include/kernel/CgiExecutor.hpp
+++ b/include/kernel/CgiExecutor.hpp
@@ -20,7 +20,6 @@ public:
     ~CgiExecutor();
 
 private:
-    std::map<int /* exec_pid */, IHandler*> _cgi_handler_map;
     std::string _script_path;
 
 private:

--- a/include/kernel/CgiExecutor.hpp
+++ b/include/kernel/CgiExecutor.hpp
@@ -34,6 +34,8 @@ private:
                                    const std::string& cgi_extension);
     char** _get_env(webshell::Request& request);
     void _free_env(char** env, size_t size);
+
+    IHandler* _handler;
 };
 
 } // namespace webkernel

--- a/include/kernel/CgiHandler.hpp
+++ b/include/kernel/CgiHandler.hpp
@@ -8,7 +8,7 @@ namespace webkernel
 class CgiHandler : public IHandler
 {
 public:
-    CgiHandler(webshell::Request& request, int client_fd);
+    CgiHandler(int client_fd, pid_t pid);
     ~CgiHandler();
     void handle_event(int fd, uint32_t events);
 
@@ -16,5 +16,6 @@ private:
     // webshell::Request& _request;
     std::string _buffer;
     int _client_fd;
+    pid_t _pid;
 };
 } // namespace webkernel

--- a/include/kernel/Reactor.hpp
+++ b/include/kernel/Reactor.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <sys/epoll.h>
 #include <unistd.h>
+#include <vector>
 
 extern volatile sig_atomic_t stop_flag;
 
@@ -27,6 +28,7 @@ public:
     void remove_handler(int fd);
     void
     modify_handler(int fd, uint32_t events_to_add, uint32_t events_to_remove);
+    std::vector<int /* fd */> get_active_fds(void) const;
 
     class InterruptException : public std::exception
     {

--- a/include/utils/ExecuteWithUnwind.hpp
+++ b/include/utils/ExecuteWithUnwind.hpp
@@ -6,16 +6,14 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 14:42:31 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/02/23 16:21:46 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/02/23 20:18:13 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UNWIND_EXEC_HPP
 #define UNWIND_EXEC_HPP
 
-#include <exception>
-
-class ExecuteWithUnwind : public std::exception
+class ExecuteWithUnwind
 {
 
 public:

--- a/include/utils/ExecuteWithUnwind.hpp
+++ b/include/utils/ExecuteWithUnwind.hpp
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ExecuteWithUnwind.hpp                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/27 14:42:31 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/02/23 16:21:46 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef UNWIND_EXEC_HPP
+#define UNWIND_EXEC_HPP
+
+#include <exception>
+
+class ExecuteWithUnwind : public std::exception
+{
+
+public:
+    ExecuteWithUnwind(const char *path, char **args, char **env);
+    ~ExecuteWithUnwind() throw();
+    ExecuteWithUnwind(const ExecuteWithUnwind& other);
+    int execute();
+
+private:
+    ExecuteWithUnwind(void);
+    ExecuteWithUnwind& operator=(const ExecuteWithUnwind& other);
+
+    const char *_path;
+    char **_args;
+    char **_env;
+};
+
+#endif

--- a/include/utils/Logger.hpp
+++ b/include/utils/Logger.hpp
@@ -59,10 +59,11 @@ private:
 
 } // namespace weblog
 
-#define LOG(level, message)                                                 \
-    do {                                                                    \
-        weblog::Logger::instance()->log(                                    \
-            level,                                                          \
-            std::string("\t[") + __FILE__ + ":" + utils::to_string(__LINE__) \
-                + "] " + utils::to_string(message));                        \
+#define LOG(level, message)                                                    \
+    do {                                                                       \
+        weblog::Logger::instance()->log(                                       \
+            level,                                                             \
+            std::string("\t[" + utils::to_string(getpid()) + "][") + __FILE__ + ":" \
+                + utils::to_string(__LINE__) + "] "                            \
+                + utils::to_string(message));                                  \
     } while (0)

--- a/include/utils/ReturnWithUnwind.hpp
+++ b/include/utils/ReturnWithUnwind.hpp
@@ -6,16 +6,14 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 14:42:31 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/02/23 14:45:43 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/02/23 20:18:05 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef UNWIND_RETURN_HPP
 #define UNWIND_RETURN_HPP
 
-#include <exception>
-
-class ReturnWithUnwind : public std::exception
+class ReturnWithUnwind
 {
 
 public:

--- a/include/utils/ReturnWithUnwind.hpp
+++ b/include/utils/ReturnWithUnwind.hpp
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ReturnWithUnwind.hpp                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/27 14:42:31 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/02/23 14:45:43 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef UNWIND_RETURN_HPP
+#define UNWIND_RETURN_HPP
+
+#include <exception>
+
+class ReturnWithUnwind : public std::exception
+{
+
+public:
+    ReturnWithUnwind(int status);
+    ~ReturnWithUnwind() throw();
+    ReturnWithUnwind(const ReturnWithUnwind& other);
+    int status();
+
+private:
+    ReturnWithUnwind(void);
+    ReturnWithUnwind& operator=(const ReturnWithUnwind& other);
+
+    int _status;
+};
+
+#endif

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -1,5 +1,6 @@
 #include "CgiExecutor.hpp"
 #include "CgiHandler.hpp"
+#include "ExecuteWithUnwind.hpp"
 #include "HttpException.hpp"
 #include "Logger.hpp"
 #include "Reactor.hpp"
@@ -195,13 +196,13 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
             }
             close(pipefd[1]);
 
-            // char* argv[2];
-            // argv[0] = strdup("loop.sh");
-            // argv[1] = NULL;
+            char* argv[2];
+            argv[0] = strdup("loop.sh");
+            argv[1] = NULL;
             // if (!execve(_script_path.c_str(), argv_null, environ)) {
 
             //we catch this in the main so all destructors are called before
-            throw "./cgi-bin/loop.sh";
+            throw ExecuteWithUnwind("./cgi-bin/loop.sh", argv, environ);
             
             // execve("./cgi-bin/loop.sh", argv, environ);
             // abort();

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -3,6 +3,7 @@
 #include "HttpException.hpp"
 #include "Logger.hpp"
 #include "Reactor.hpp"
+#include "ReturnWithUnwind.hpp"
 #include "defines.hpp"
 #include <cerrno>
 #include <cstdio>
@@ -154,7 +155,6 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
     (void)request;
     LOG(weblog::CRITICAL, "Handling CGI request...");
     int pipefd[2];
-    // _handler = NULL;
 
     if (pipe(pipefd) == -1) {
         throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
@@ -167,7 +167,6 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
         if (pid > 0) {
             _handler = new CgiHandler(client_fd, pid);
             Reactor::instance()->register_handler(pipefd[0], _handler, EPOLLIN);
-            // Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN | EPOLLOUT);
             close(pipefd[1]);
 
             // the monitor process
@@ -175,25 +174,24 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
 
             if (pid_unwanted_child == -1) {
                 close(pipefd[0]);
+                kill(pid, SIGKILL);
+                // return ; //TODO: why does this not work?
                 throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
-                                           "Failed to fork");
+                                           "Failed to fork monitor process");
             }
             if (pid_unwanted_child == 0) {
                 close(pipefd[0]);
                 sleep(3);
                 kill(pid, SIGKILL);
-                int hehe = 9;
-                throw hehe;
-                // exit(SUCCESS);
+                throw ReturnWithUnwind(SUCCESS);
             }
         }
         // child of the exec process
         else if (pid == 0) {
-            // TODO: close all the file descriptors maybe by loop????
             close(pipefd[0]);
             if (dup2(pipefd[1], STDOUT_FILENO) == -1) {
                 close(pipefd[1]);
-                exit(FAILURE);
+                throw ReturnWithUnwind(FAILURE);
             }
             close(pipefd[1]);
 
@@ -216,7 +214,7 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
                                        "Failed to fork");
         }
     }
-    catch (std::exception& e) {
+    catch (utils::HttpException& e) {
         Reactor::instance()->remove_handler(pipefd[0]);
         close(pipefd[0]);
         close(pipefd[1]);

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -18,10 +18,12 @@ extern char** environ;
 namespace webkernel
 {
 
-CgiExecutor::CgiExecutor() {}
+CgiExecutor::CgiExecutor() : _handler(NULL) {}
 
 CgiExecutor::~CgiExecutor()
 {
+    if (_handler)
+        delete _handler;
 }
 
 std::string CgiExecutor::_replace_route(std::string route_path,
@@ -152,7 +154,7 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
     (void)request;
     LOG(weblog::CRITICAL, "Handling CGI request...");
     int pipefd[2];
-    IHandler* handler = NULL;
+    // _handler = NULL;
 
     if (pipe(pipefd) == -1) {
         throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
@@ -163,8 +165,8 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
 
         // parent
         if (pid > 0) {
-            handler = new CgiHandler(client_fd, pid);
-            Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN);
+            _handler = new CgiHandler(client_fd, pid);
+            Reactor::instance()->register_handler(pipefd[0], _handler, EPOLLIN);
             // Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN | EPOLLOUT);
             close(pipefd[1]);
 

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -165,7 +165,8 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
         // parent
         if (pid > 0) {
             handler = new CgiHandler(client_fd, pid);
-            Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN | EPOLLOUT);
+            Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN);
+            // Reactor::instance()->register_handler(pipefd[0], handler, EPOLLIN | EPOLLOUT);
             close(pipefd[1]);
 
             // the monitor process
@@ -197,9 +198,10 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
             argv[0] = strdup("loop.sh");
             argv[1] = NULL;
             // if (!execve(_script_path.c_str(), argv_null, environ)) {
-            execve("/workspace/cgi-bin/loop.sh", argv, environ);
+            execve("./cgi-bin/loop.sh", argv, environ);
+            // abort();
             perror(strerror(errno));
-            sleep(100);
+            // sleep(100);
             exit(FAILURE);
         }
         else {

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -22,7 +22,6 @@ CgiExecutor::CgiExecutor() {}
 
 CgiExecutor::~CgiExecutor()
 {
-    LOG(weblog::DEBUG, "CgiExecutor destroyed");
 }
 
 std::string CgiExecutor::_replace_route(std::string route_path,
@@ -181,7 +180,9 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
                 close(pipefd[0]);
                 sleep(3);
                 kill(pid, SIGKILL);
-                exit(SUCCESS);
+                int hehe = 9;
+                throw hehe;
+                // exit(SUCCESS);
             }
         }
         // child of the exec process
@@ -194,15 +195,19 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
             }
             close(pipefd[1]);
 
-            char* argv[2];
-            argv[0] = strdup("loop.sh");
-            argv[1] = NULL;
+            // char* argv[2];
+            // argv[0] = strdup("loop.sh");
+            // argv[1] = NULL;
             // if (!execve(_script_path.c_str(), argv_null, environ)) {
-            execve("./cgi-bin/loop.sh", argv, environ);
+
+            //we catch this in the main so all destructors are called before
+            throw "./cgi-bin/loop.sh";
+            
+            // execve("./cgi-bin/loop.sh", argv, environ);
             // abort();
-            perror(strerror(errno));
-            // sleep(100);
-            exit(FAILURE);
+            // perror(strerror(errno));
+            // // sleep(100);
+            // exit(FAILURE);
         }
         else {
             throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -194,10 +194,10 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
             close(pipefd[1]);
 
             char* argv[2];
-            argv[0] = strdup("hello_world.sh");
+            argv[0] = strdup("loop.sh");
             argv[1] = NULL;
             // if (!execve(_script_path.c_str(), argv_null, environ)) {
-            execve("/workspace/cgi-bin/hello_world.sh", argv, environ);
+            execve("/workspace/cgi-bin/loop.sh", argv, environ);
             perror(strerror(errno));
             sleep(100);
             exit(FAILURE);

--- a/source/kernel/CgiHandler.cpp
+++ b/source/kernel/CgiHandler.cpp
@@ -5,17 +5,18 @@
 #include "defines.hpp"
 #include "kernelUtils.hpp"
 #include "utils.hpp"
+#include <cstdlib>
 #include <iostream>
 #include <sys/epoll.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 
 namespace webkernel
 {
 
-CgiHandler::CgiHandler(webshell::Request& request, int client_fd) :
-    _buffer(""), _client_fd(client_fd)
+CgiHandler::CgiHandler(int client_fd, pid_t pid) :
+    _buffer(""), _client_fd(client_fd), _pid(pid)
 {
-    (void)request;
 }
 
 CgiHandler::~CgiHandler() {}
@@ -35,22 +36,43 @@ void CgiHandler::handle_event(int fd /*read_end*/, uint32_t events)
         if (bytes_read > 0) {
             _buffer.append(buffer, bytes_read);
         }
-        else if (bytes_read == 0) {
-            webkernel::ConnectionHandler::instance()->prepare_write(_client_fd,
-                                                                    _buffer);
-            webkernel::Reactor::instance()->remove_handler(fd);
-            // TODO: delete this;
-        }
         else {
             throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
                                        "read() failed: "
                                            + std::string(strerror(errno)));
         }
     }
-    else if (events & EPOLLHUP) {
-        webkernel::ConnectionHandler::instance()->prepare_write(_client_fd,
-                                                                _buffer);
-        webkernel::Reactor::instance()->remove_handler(fd);
+    else if (events & EPOLLOUT) {
+        LOG(weblog::CRITICAL, "Waiting for child: " + utils::to_string(_pid));
+        int status;
+        int ret = waitpid(_pid, &status, WNOHANG);
+
+        if (ret == -1) {
+            throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
+                                       "waitpid() failed: "
+                                           + std::string(strerror(errno)));
+        }
+        else if (ret == 0) {
+            LOG(weblog::CRITICAL, "Child still running");
+            // child is still running
+            return;
+        }
+        else {
+            LOG(weblog::CRITICAL, "Child exited with status: "
+                                       + utils::to_string(status));
+            // child has exited
+            if (WIFEXITED(status)) {
+                LOG(weblog::CRITICAL, "Child exited normally");
+                webkernel::ConnectionHandler::instance()->prepare_write(
+                    _client_fd, _buffer);
+                webkernel::Reactor::instance()->remove_handler(fd);
+            }
+            else {
+                LOG(weblog::CRITICAL, "Child exited abnormally");
+                throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,
+                                           "Child exited abnormally");
+            }
+        }
     }
     else {
         throw utils::HttpException(webshell::INTERNAL_SERVER_ERROR,

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -236,7 +236,9 @@ void ConnectionHandler::_handle_write(int fd)
     const EventProcessingState& process_state = _processor.state(fd);
 
     if (process_state & ERROR) {
+    // if (_error_buffer.find(fd) != _error_buffer.end()) {
         _send_error(fd);
+        Reactor::instance()->remove_handler(fd);
     }
     else if (process_state & COMPELETED) {
         _send_normal(fd);
@@ -299,6 +301,8 @@ void ConnectionHandler::_send_error(int fd)
     else {
         LOG(weblog::DEBUG,
             "Error buffer found for fd: " + utils::to_string(fd));
+        LOG(weblog::DEBUG,
+            "Error content: \n" + utils::replaceCRLF(_error_buffer[fd]));
         int bytes_sent = send(fd, it->second.c_str(), it->second.size(), 0);
 
         _error_buffer.erase(it);

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -14,6 +14,7 @@
 #include <sys/epoll.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <iostream>
 
 namespace webkernel
 {
@@ -227,6 +228,7 @@ void ConnectionHandler::_process_read_data(int fd,
     }
 }
 
+
 void ConnectionHandler::_handle_write(int fd)
 {
     LOG(weblog::DEBUG,
@@ -238,7 +240,6 @@ void ConnectionHandler::_handle_write(int fd)
     if (process_state & ERROR) {
     // if (_error_buffer.find(fd) != _error_buffer.end()) {
         _send_error(fd);
-        Reactor::instance()->remove_handler(fd);
     }
     else if (process_state & COMPELETED) {
         _send_normal(fd);

--- a/source/kernel/Kernel.cpp
+++ b/source/kernel/Kernel.cpp
@@ -18,7 +18,7 @@
 namespace webkernel
 {
 
-Kernel::Kernel()
+Kernel::Kernel() : _acceptor(NULL), _session_manager(NULL)
 {
     webconfig::Config* config = webconfig::Config::instance();
 
@@ -62,6 +62,7 @@ Kernel& Kernel::operator=(const Kernel& other)
     LOG(weblog::DEBUG, "Kernel::operator=(const Kernel& other)");
     if (this != &other) {
         _acceptor = other._acceptor;
+        _session_manager = other._session_manager;
     }
     return (*this);
 }
@@ -72,6 +73,10 @@ Kernel::~Kernel()
     Reactor::destroy();
     if (_acceptor) {
         delete _acceptor;
+    }
+    if (_session_manager)
+    {
+        delete _session_manager;
     }
 }
 

--- a/source/kernel/Reactor.cpp
+++ b/source/kernel/Reactor.cpp
@@ -66,6 +66,7 @@ void Reactor::run(void)
 {
     LOG(weblog::DEBUG, "Reactor::run()");
     struct epoll_event events[MAX_EVENTS];
+    memset(events, 0, sizeof(events));
 
     while (true) {
         _check_interrupt();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,11 +6,12 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/29 22:49:41 by lyeh              #+#    #+#             */
-/*   Updated: 2025/02/22 21:20:16 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/02/23 20:22:52 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "Config.hpp"
+#include "ExecuteWithUnwind.hpp"
 #include "Kernel.hpp"
 #include "Logger.hpp"
 #include "defines.hpp"
@@ -64,15 +65,16 @@ int main(int argc, char** argv)
     //     config->destroy();
     //     weblog::Logger::destroy();
     // }
-    catch (const char *lol)
+    catch (ExecuteWithUnwind& e)
     {
-        char* argv[2];
-        argv[0] = strdup("loop.sh");
-        argv[1] = NULL;
+        // char* argv[2];
+        // argv[0] = strdup("loop.sh");
+        // argv[1] = NULL;
         config->destroy();
         weblog::Logger::destroy();
-        execve(lol, argv, environ);
-        return (-1);
+        e.execute();
+        // execve(lol, argv, environ);
+        return (FAILURE);
     }
     catch (int i)
     {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/29 22:49:41 by lyeh              #+#    #+#             */
-/*   Updated: 2024/08/18 16:31:15 by lyeh             ###   ########.fr       */
+/*   Updated: 2025/02/22 21:20:16 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 #include <iostream>
 
 volatile sig_atomic_t stop_flag = 0;
+extern char **environ; 
 
 void handle_terminate_signal(int signum)
 {
@@ -53,6 +54,32 @@ int main(int argc, char** argv)
         webkernel::Kernel kernel;
 
         kernel.run();
+    }
+    // catch (const std::exception& e) {
+    //     // ExecuteWithUnwind: unwind whole webserv then execute the external process
+    //     // ReturnWithUnwind: unwind whole webserv then return on main
+    //     if (execute_cgi) {}
+    //     else if (i) {}
+        
+    //     config->destroy();
+    //     weblog::Logger::destroy();
+    // }
+    catch (const char *lol)
+    {
+        char* argv[2];
+        argv[0] = strdup("loop.sh");
+        argv[1] = NULL;
+        config->destroy();
+        weblog::Logger::destroy();
+        execve(lol, argv, environ);
+        return (-1);
+    }
+    catch (int i)
+    {
+        (void)i;
+        config->destroy();
+        weblog::Logger::destroy();
+        return 0;
     }
     catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;

--- a/source/shell/Response.cpp
+++ b/source/shell/Response.cpp
@@ -105,8 +105,8 @@ std::string Response::serialize() const
     if (_headers.find("transfer-encoding") == _headers.end()) {
         response += "\r\n";
     }
-    LOG(weblog::WARNING,
-        "serialize response: \n" + utils::replaceCRLF(response));
+    // LOG(weblog::WARNING,
+    //     "serialize response: \n" + utils::replaceCRLF(response));
 
     return (response);
 }

--- a/source/shell/Response.cpp
+++ b/source/shell/Response.cpp
@@ -1,5 +1,6 @@
 #include "Response.hpp"
 #include "Logger.hpp"
+#include "debugUtils.hpp"
 #include "defines.hpp"
 #include "shellUtils.hpp"
 #include "utils.hpp"
@@ -104,6 +105,8 @@ std::string Response::serialize() const
     if (_headers.find("transfer-encoding") == _headers.end()) {
         response += "\r\n";
     }
+    LOG(weblog::WARNING,
+        "serialize response: \n" + utils::replaceCRLF(response));
 
     return (response);
 }

--- a/source/utils/ExecuteWithUnwind.cpp
+++ b/source/utils/ExecuteWithUnwind.cpp
@@ -1,0 +1,41 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ExecuteWithUnwind.cpp                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/27 14:42:29 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/02/23 16:22:57 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ExecuteWithUnwind.hpp"
+#include <unistd.h>
+
+ExecuteWithUnwind::ExecuteWithUnwind(const char *path, char **args, char **env)
+{
+    _path = path;
+    _args = args;
+    _env = env;
+}
+
+ExecuteWithUnwind::~ExecuteWithUnwind() throw()
+{
+    if (_path)
+        delete _path;
+    if (_args)
+        delete _args;
+    if (_env)
+        delete _env;
+}
+
+ExecuteWithUnwind::ExecuteWithUnwind(const ExecuteWithUnwind& other) : _path(other._path), _args(other._args), _env(other._env)
+{
+}
+
+int ExecuteWithUnwind::execute()
+{
+    int status = execve(_path, _args, _env);
+    return (status);
+}

--- a/source/utils/ReturnWithUnwind.cpp
+++ b/source/utils/ReturnWithUnwind.cpp
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ReturnWithUnwind.cpp                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/27 14:42:29 by mhuszar           #+#    #+#             */
+/*   Updated: 2025/02/23 14:46:37 by mhuszar          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ReturnWithUnwind.hpp"
+
+ReturnWithUnwind::ReturnWithUnwind(int status)
+{
+    _status = status;
+}
+
+ReturnWithUnwind::~ReturnWithUnwind() throw()
+{
+
+}
+
+ReturnWithUnwind::ReturnWithUnwind(const ReturnWithUnwind& other)
+{
+    this->_status = other._status;
+}
+
+int ReturnWithUnwind::status()
+{
+    return (_status);
+}


### PR DESCRIPTION
Added two new classes to throw for the stack unwind after `fork()`. They do not inherit from `std::exception` anymore as they are not truly exceptions and as I discovered that way they also might get caught on the way to `main` and possibly never reach it.

We still have an active leak issue: since `CgiExecutor` is a single unique object we reuse for all execution calls, and it holds one `CgiHandler *` as a private variable, it gets `new`ed and overwritten of every call of cgi execution. This leads to 48 bytes of leak per subsequent CGI request.

As discussed we could make a map that holds all Handlers and deletes them at destruction. But since the lifetime of `CgiExecutor` matches the lifetime of the webserver and this would hold all the inactive handler objects until shutdown, I think it's a bad memory management practice.

So we should probably come up with something else.

Opened #155 for this.