### PR TITLE
[FEAT] Improve Request state machine

### DIFF
--- a/include/defines.hpp
+++ b/include/defines.hpp
@@ -167,6 +167,7 @@ enum RequestHeaderState
     FIELD_END_CRLF,
     CHECK_OBS_FOLD,
     HEADER_END_CRLF,
+    QUOTED,
     END_HEADERS
 };
 

--- a/include/kernel/CgiExecutor.hpp
+++ b/include/kernel/CgiExecutor.hpp
@@ -38,6 +38,7 @@ private:
     std::vector<std::string> _get_env(webshell::Request& request);
     char** _convert_to_str_array(std::vector<std::string> vec);
     void _free_array(char** arr, size_t size);
+    void _close_all_fds(std::vector<int> vec);
 
     IHandler* _handler;
 };

--- a/include/kernel/Reactor.hpp
+++ b/include/kernel/Reactor.hpp
@@ -29,6 +29,7 @@ public:
     void
     modify_handler(int fd, uint32_t events_to_add, uint32_t events_to_remove);
     std::vector<int /* fd */> get_active_fds(void) const;
+    void destroy_tree();
 
     class InterruptException : public std::exception
     {

--- a/include/shell/HeaderAnalyzer.hpp
+++ b/include/shell/HeaderAnalyzer.hpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:54 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:49:23 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/02 00:01:01 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ private:
     std::map<std::string, std::string> _cookie_map;
     std::string _key;
     std::string _val;
+    bool _escape;
 
 private:
     void _start_header(unsigned char c);
@@ -53,6 +54,8 @@ private:
     void _field_end_crlf(unsigned char c);
     void _check_obs_fold(unsigned char c);
     void _header_end_crlf(unsigned char c);
+    void _quoted(unsigned char c);
+
 };
 
 } // namespace webshell

--- a/include/shell/RequestLineAnalyzer.hpp
+++ b/include/shell/RequestLineAnalyzer.hpp
@@ -33,6 +33,8 @@ private:
     std::string _uri;
     std::string _version;
 
+    int _pos;
+
 private:
     void _validate_start(unsigned char c);
     void _check_lf(unsigned char c);

--- a/source/config/Config.cpp
+++ b/source/config/Config.cpp
@@ -30,7 +30,8 @@ Config::Config(const std::string& filename) : _current_block_level(GLOBAL)
     if (!_file_stream.is_open() || !_file_stream.good()) {
         throw std::runtime_error("Failed to open file: " + _filename);
     }
-    _parse();
+    _parse(); //TODO: this constructor throws sometimes
+    _file_stream.close();
 }
 
 std::string Config::filename(void) const

--- a/source/kernel/ARequestHandler.cpp
+++ b/source/kernel/ARequestHandler.cpp
@@ -194,7 +194,10 @@ ARequestHandler::_get_resource_path(const webconfig::RequestConfig& config,
     std::string resource_path = request_path.substr(config.route.size());
     std::string full_path;
 
-    if (!config.alias.empty()) {
+    if (!config.cgi_path.empty()) {
+        base_dir = config.cgi_path;
+    }
+    else if (!config.alias.empty()) {
         base_dir = config.alias;
     }
     full_path = utils::join(base_dir, resource_path);

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -111,6 +111,7 @@ void CgiExecutor::cgi_exec(webshell::Request& request, int client_fd)
             //close all fds here in a loop
             std::vector<int> fd_vec = Reactor::instance()->get_active_fds();
             _close_all_fds(fd_vec);
+            Reactor::instance()->destroy_tree();
             execve(_script_path.c_str(), argv, env);
             throw ReturnWithUnwind(FAILURE);
             // throw ExecuteWithUnwind(strdup(_script_path.c_str()), argv, env);

--- a/source/kernel/Reactor.cpp
+++ b/source/kernel/Reactor.cpp
@@ -120,6 +120,11 @@ void Reactor::modify_handler(int fd,
     }
 }
 
+void Reactor::destroy_tree()
+{
+    close(_epoll_fd);
+}
+
 void Reactor::remove_handler(int fd)
 {
     std::map<int, IHandler*>::iterator it = _handlers.find(fd);

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:50:20 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/01 21:36:36 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -369,7 +369,6 @@ void HeaderFieldValidator::_feed_hostname(unsigned char c)
     case URI_HOST_REGNAME:
         _uri_host_regname(c);
         break;
-    // TODO: can (should) we do IPV6 as well?
     case URI_PORT:
         _uri_port(c);
         break;

--- a/source/shell/RequestLineAnalyzer.cpp
+++ b/source/shell/RequestLineAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/05 16:52:31 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/03/01 21:20:34 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/02 00:23:13 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -144,7 +144,7 @@ void RequestLineAnalyzer::_check_lf(unsigned char c)
 
 void RequestLineAnalyzer::_analyze_method(unsigned char c)
 {
-    if (c == ' ') {
+    if (_is_ows(c)) {
         _state = URI;
     }
     else if (!_is_tchar(c)) {
@@ -158,10 +158,13 @@ void RequestLineAnalyzer::_analyze_method(unsigned char c)
 
 bool RequestLineAnalyzer::_collect_uri(unsigned char c)
 {
-    if (c == ' ') {
+    if (_is_ows(c)) {
         _state = VERSION;
         return (true);
     }
+    else if (c == '\r' || c == '\n')
+        throw utils::HttpException(webshell::BAD_REQUEST,
+                                   "request-line incomplete");
     else {
         _uri.push_back(c);
         return (false);

--- a/source/shell/UriAnalyzer.cpp
+++ b/source/shell/UriAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/09 18:21:05 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/01/27 17:49:33 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/01 21:39:05 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -351,9 +351,7 @@ void UriAnalyzer::_uri_host_ipv4(unsigned char c)
         if (!_ipv_digit) {
             goto except;
         }
-        else {
-            _ipv_digit = false;
-        }
+        _ipv_digit = false;
         _ipv_dot++;
         _host.push_back(c);
     }


### PR DESCRIPTION
So based on the RFC it seems like comments `(` can only be part of "Via" header field so since that does not concern us, I will not prioritize implementing this.

But I did set up some parsing logic for quoted strings in header field values.

Also discovered a parsing error with accepting random `\n` in the middle of URI so I fixed that.

@LeaYeh will need some help from you cause I want to see if your IPv6 support function can be integrated with my analyzer.