### PR TITLE
[FIX] Fix config corner cases from Lukas

### DIFF
--- a/source/config/ConfigHttpBlock.cpp
+++ b/source/config/ConfigHttpBlock.cpp
@@ -92,6 +92,11 @@ std::string ConfigHttpBlock::autoindex_page(void) const
     return (_autoindex_page);
 }
 
+std::string ConfigHttpBlock::error_page(void) const
+{
+    return (_error_page);
+}
+
 void ConfigHttpBlock::_parse_config_directive(const std::string& line)
 {
     std::string directive = _get_directive_name(line);

--- a/source/config/ConfigServerBlock.cpp
+++ b/source/config/ConfigServerBlock.cpp
@@ -3,6 +3,7 @@
 #include "configUtils.hpp"
 #include "defines.hpp"
 #include "utils.hpp"
+#include "IPAddress.hpp"
 #include <string>
 
 namespace webconfig
@@ -150,7 +151,17 @@ ConfigServerBlock::_parse_listen(const std::string& line,
 
     size_t pos = value.find(":");
     if (pos == std::string::npos) {
-        return std::make_pair(value, std::string("80"));
+        throw std::invalid_argument("Listen directive has invalid value: "
+                                    + value);
+    }
+    std::string ip = value.substr(0, pos);
+    std::string port = value.substr(pos + 1);
+    if (!utils::IPAddress::is_valid_ip(ip)) {
+        throw std::invalid_argument("Listen directive has invalid IP: " + ip);
+    }
+    if (!utils::IPAddress::is_valid_port(port)) {
+        throw std::invalid_argument("Listen directive has invalid port: "
+                                    + port);
     }
     return (std::make_pair(value.substr(0, pos), value.substr(pos + 1)));
 }

--- a/source/config/ConfigServerBlock.cpp
+++ b/source/config/ConfigServerBlock.cpp
@@ -1,9 +1,9 @@
 #include "ConfigServerBlock.hpp"
+#include "IPAddress.hpp"
 #include "Logger.hpp"
 #include "configUtils.hpp"
 #include "defines.hpp"
 #include "utils.hpp"
-#include "IPAddress.hpp"
 #include <string>
 
 namespace webconfig
@@ -186,8 +186,24 @@ ConfigServerBlock::_parse_keep_alive_timeout(const std::string& line,
                                              const std::string& directive)
 {
     std::string value = extract_directive_value(line, directive);
+    ssize_t num;
 
-    return (utils::stoi(value));
+    if (value.length() > 3) {
+        throw std::invalid_argument(
+            "Keepalive timeout directive has invalid value: " + value);
+    }
+    try {
+        num = utils::stoi(value);
+        if (num < 0) {
+            throw;
+        }
+    }
+    catch (const std::invalid_argument& e) {
+        throw std::invalid_argument(
+            "Keepalive timeout directive has invalid value: " + value);
+    }
+
+    return (num);
 }
 
 } // namespace webconfig

--- a/source/shell/ResponseBuilder.cpp
+++ b/source/shell/ResponseBuilder.cpp
@@ -1,4 +1,5 @@
 #include "ResponseBuilder.hpp"
+#include "Config.hpp"
 #include "TemplateEngine.hpp"
 #include "defines.hpp"
 #include "shellUtils.hpp"
@@ -74,12 +75,18 @@ std::string ResponseBuilder::_render_error_page(StatusCode status_code,
 {
     static webkernel::TemplateEngine template_engine;
 
-    // TODO: Replace the error page path with config
-    template_engine.load_template("./www/html/error_page.html");
-    template_engine.set_variable("STATUS_CODE", utils::to_string(status_code));
-    template_engine.set_variable("ERROR_REASON", message);
+    try {
+        template_engine.load_template(
+            webconfig::Config::instance()->http_block().error_page());
+        template_engine.set_variable("STATUS_CODE",
+                                     utils::to_string(status_code));
+        template_engine.set_variable("ERROR_REASON", message);
 
-    return (template_engine.render());
+        return (template_engine.render());
+    }
+    catch (const std::exception& e) {
+        return (error(INTERNAL_SERVER_ERROR, e.what(), TEXT_PLAIN).body());
+    }
 }
 
 std::string ResponseBuilder::_render_json(StatusCode status_code,

--- a/source/utils/IPAddress.cpp
+++ b/source/utils/IPAddress.cpp
@@ -1,6 +1,7 @@
 #include "IPAddress.hpp"
 #include "utils.hpp"
 #include <arpa/inet.h>
+#include <cstddef>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -10,14 +11,14 @@ namespace utils
 
 bool IPAddress::is_ipv4(const std::string& ip)
 {
-    std::string::size_type pos = 0;
-    int count = 0;
-    int num = 0;
+    size_t count = 0;
+    size_t pos = 0;
+    size_t num = 0;
     bool segment_start = true;
 
     while (pos < ip.size()) {
         if (std::isdigit(ip[pos])) {
-            if (segment_start && ip[pos] == '0' && pos + 1 < ip.size()
+            if (segment_start && ip[pos] == '0' && (pos + 1) < ip.length()
                 && std::isdigit(ip[pos + 1])) {
                 return (false);
             }
@@ -25,7 +26,7 @@ bool IPAddress::is_ipv4(const std::string& ip)
             num = num * 10 + (ip[pos] - '0');
         }
         else if (ip[pos] == '.') {
-            if (num > 255) {
+            if (num > 255 || pos > (count * 3 + 3)) {
                 return (false);
             }
             num = 0;


### PR DESCRIPTION
```
listen 127.0.0.1:808#0;

listen 127.0.0.1::8080;
listen 127.0.0..1:8080;

listen 127.0.555.1:8080;

listen 1;27.0.0.1:8080;

listen -127.0.0.1:8080;

listen 127.0.0.1:8080808080808080808;
listen 1200000000000000000007.0.0.1:8080;

listen 127.0.0.100;

keep_alive_timeout -500;


// TODO: Replace the error page path with config
ResponseBuilder.cpp:77
Could not open template file: ./wwsssw/html/error_page.html

if the cgi script has no permission

```