### PR TITLE
[FIX] Fix the crash on CGI stress test

### DIFF
--- a/include/kernel/Reactor.hpp
+++ b/include/kernel/Reactor.hpp
@@ -30,6 +30,7 @@ public:
     modify_handler(int fd, uint32_t events_to_add, uint32_t events_to_remove);
     std::vector<int /* fd */> get_active_fds(void) const;
     void destroy_tree();
+    bool handler_exists(int fd) const;
 
     class InterruptException : public std::exception
     {

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -89,6 +89,7 @@ void ConnectionHandler::prepare_write(int fd, const std::string& buffer)
         close_connection(fd, weblog::ERROR, "Write buffer allocation failed");
     }
 
+    // TODO: Check why who call the prepare_write even though the fd is not exist any more.
     _write_buffer[fd].append(buffer);
     Reactor::instance()->modify_handler(fd, EPOLLOUT, 0);
 }

--- a/source/kernel/RequestProcessor.cpp
+++ b/source/kernel/RequestProcessor.cpp
@@ -48,7 +48,7 @@ bool RequestProcessor::analyze(int fd, std::string& buffer)
         _analyzer_pool[fd] = webshell::RequestAnalyzer(&buffer);
         reset_state(fd);
     }
-    LOG(weblog::CRITICAL, "buffer: " + buffer);
+    LOG(weblog::WARNING, "buffer: " + buffer);
     while (i < buffer.size()) {
         _analyzer_pool[fd].feed(buffer[i]);
         if (_analyzer_pool[fd].is_complete()) {


### PR DESCRIPTION
Basically the issue we had with trying to modify a handler on an `fd` that is already removed is common and harmless enough to warrant just logging it and going on instead of throwing to crash as we did so far.

This way we don't crash anymore. Would be still nice to investigate why it happens.