### PR TITLE
[FIX] Fix analyzing multiple requests at the same time

### DIFF
--- a/source/kernel/RequestProcessor.cpp
+++ b/source/kernel/RequestProcessor.cpp
@@ -111,6 +111,13 @@ void RequestProcessor::process(int fd)
         }
         else {
             // TODO: For the GET request we also need to control the EPOLLIN/EPOLLOUT correctly to avoid to analyize a new request before the current request finished
+            Reactor::instance()->modify_handler(fd, EPOLLOUT, EPOLLIN);
+            // if (request.empty_buffer()) {
+            //     Reactor::instance()->modify_handler(fd, EPOLLIN, 0);
+            // }
+            // else {
+            //     Reactor::instance()->modify_handler(fd, EPOLLOUT, EPOLLIN);
+            // }
             // for GET and DELETE requests, we can send the response directly
             _handler->prepare_write(fd, response.serialize());
         }


### PR DESCRIPTION
This happened if we were not done with processing a previous request (for example waiting for a child process of CGI to finish) but already started to listen on `EPOLLIN` and parsing the next request (so getting mixed up).

We only listen on `EPOLLIN` now after sending a proper response. Analyzer is also reset and CGI Handler is freed in every case now, not just on `Connection: close`.