### PR TITLE
[FEAT] Implement `100-continue`

### DIFF
--- a/source/kernel/PostHandler.cpp
+++ b/source/kernel/PostHandler.cpp
@@ -108,6 +108,13 @@ std::string PostHandler::_process(int fd,
                                    "No write permission on file: "
                                        + _target_path);
     }
+    if (request.has_header("expect")) {
+        size_t content_length = utils::stoi(request.get_header("content-length"));
+        if (content_length > request.config().client_max_body_size) {
+            throw utils::HttpException(webshell::PAYLOAD_TOO_LARGE, "Do Not Continue");
+        }
+        throw utils::HttpException(webshell::CONTINUE, "Continue");
+    }
 
     std::string temp_file_path = request.read_chunked_body();
     if (temp_file_path.empty()) {

--- a/source/shell/HeaderFieldValidator.cpp
+++ b/source/shell/HeaderFieldValidator.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/19 18:42:39 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/03/17 22:39:13 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/18 22:14:08 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -112,10 +112,15 @@ void HeaderFieldValidator::validate(std::map<std::string, std::string>& map)
     else {
         _validate_host(map["host"]);
     }
-    if (map.find("expect") != map.end() && map["expect"] != "100-continue") {
-        throw utils::HttpException(
-            webshell::EXPECTATION_FAILED,
-            "Only accepted Expect field value is \"100-continue\"");
+    if (map.find("expect") != map.end()) {
+        if (map["expect"] != "100-continue")
+            throw utils::HttpException(
+                webshell::EXPECTATION_FAILED,
+                "Only accepted Expect field value is \"100-continue\"");
+        if (map.find("content-length") == map.end())
+            throw utils::HttpException(
+                webshell::BAD_REQUEST,
+                "Expecting Content-Length for expectation");
     }
     if (map.find("cache-control") != map.end()) {
         _validate_cache_control(map["cache-control"]);

--- a/source/utils/shellUtils.cpp
+++ b/source/utils/shellUtils.cpp
@@ -47,6 +47,10 @@ std::string status_reason_phase(const StatusCode& status_code)
         return ("Bad Gateway");
     case SERVICE_UNAVAILABLE:
         return ("Service Unavailable");
+    case PAYLOAD_TOO_LARGE:
+        return ("Payload Too Large");
+    case CONTINUE:
+        return ("Continue");
     default:
         return ("Unknown Status Code");
     }


### PR DESCRIPTION
As per RFC 7231 5.1.1.:
> An origin server **MUST**, upon receiving an HTTP/1.1 (or later)
   request-line and a complete header section that contains a
   100-continue expectation and indicates a request message body will
   follow, **either send an immediate response with a final status code,
   if that status can be determined by examining just the request-line
   and header fields, or send an immediate 100 (Continue) response to
   encourage the client to send the request's message body.  The origin
   server MUST NOT wait for the message body before sending the 100
   (Continue) response.**

Looks like if a team doesn't implement this it's natural failure
We basically dodged a bullet