### PR TITLE
[FIX] Remove exception from Reactor class

### DIFF
--- a/include/kernel/Reactor.hpp
+++ b/include/kernel/Reactor.hpp
@@ -3,7 +3,6 @@
 #include "Singleton.hpp"
 #include "defines.hpp"
 #include <csignal>
-#include <exception>
 #include <map>
 #include <sys/epoll.h>
 #include <unistd.h>
@@ -31,15 +30,6 @@ public:
     std::vector<int /* fd */> get_active_fds(void) const;
     void destroy_tree();
     bool handler_exists(int fd) const;
-
-    class InterruptException : public std::exception
-    {
-    public:
-        const char* what() const throw()
-        {
-            return STY_GRE "Shutdown webserver" STY_RES;
-        }
-    };
 
 public:
     ~Reactor();

--- a/source/kernel/CgiExecutor.cpp
+++ b/source/kernel/CgiExecutor.cpp
@@ -382,16 +382,16 @@ void CgiExecutor::_debug_execve(const std::string& exec_path,
                                 char* const argv[],
                                 char* const env[])
 {
-    LOG(weblog::WARNING, "==== Debug Execve Parameters ====");
-    LOG(weblog::WARNING, "Executable Path: " + exec_path);
-    LOG(weblog::WARNING, "Arguments:");
+    LOG(weblog::DEBUG, "==== Debug Execve Parameters ====");
+    LOG(weblog::DEBUG, "Executable Path: " + exec_path);
+    LOG(weblog::DEBUG, "Arguments:");
     for (int i = 0; argv[i] != NULL; i++) {
-        LOG(weblog::WARNING, "  argv[" + utils::to_string(i) + "]: " + argv[i]);
+        LOG(weblog::DEBUG, "  argv[" + utils::to_string(i) + "]: " + argv[i]);
     }
 
-    LOG(weblog::WARNING, "Environment Variables:");
+    LOG(weblog::DEBUG, "Environment Variables:");
     for (int i = 0; env[i] != NULL; ++i) {
-        LOG(weblog::WARNING, "  env[" + utils::to_string(i) + "]: " + env[i]);
+        LOG(weblog::DEBUG, "  env[" + utils::to_string(i) + "]: " + env[i]);
     }
 }
 

--- a/source/kernel/ConnectionHandler.cpp
+++ b/source/kernel/ConnectionHandler.cpp
@@ -100,7 +100,7 @@ void ConnectionHandler::prepare_error(int fd, const utils::HttpException& e)
     webshell::Response err_response = webshell::ResponseBuilder::error(
         e.status_code(), e.reasonDetail(), e.contentType());
 
-    LOG(weblog::WARNING, "Error response: \n" + err_response.serialize());
+    LOG(weblog::DEBUG, "Error response: \n" + err_response.serialize());
 
     _error_buffer[fd].append(err_response.serialize());
     Reactor::instance()->modify_handler(fd, EPOLLOUT, EPOLLIN);
@@ -167,11 +167,11 @@ void ConnectionHandler::_handle_read_eof(int fd)
     if (_write_buffer.find(fd) == _write_buffer.end()
         || _write_buffer[fd].empty()) {
         close_connection(
-            fd, weblog::INFO, "Read 0 bytes, client closing connection");
+            fd, weblog::DEBUG, "Read 0 bytes, client closing connection");
     }
     else {
         close_connection(fd,
-                         weblog::WARNING,
+                         weblog::DEBUG,
                          "Read 0 bytes, client closing connection, "
                          "but there is data to write");
     }
@@ -266,9 +266,9 @@ void ConnectionHandler::_send_normal(int fd)
                                    "send() failed.");
     }
     else if (bytes_sent == 0) {
-        LOG(weblog::INFO, "Write 0 bytes, client closing connection");
+        LOG(weblog::DEBUG, "Write 0 bytes, client closing connection");
         close_connection(
-            fd, weblog::INFO, "Write 0 bytes, client closing connection");
+            fd, weblog::DEBUG, "Write 0 bytes, client closing connection");
     }
     else {
         LOG(weblog::DEBUG,
@@ -283,7 +283,7 @@ void ConnectionHandler::_send_error(int fd)
     std::map<int, std::string>::iterator it = _error_buffer.find(fd);
 
     if (it == _error_buffer.end()) {
-        LOG(weblog::WARNING,
+        LOG(weblog::DEBUG,
             "No error buffer found for fd: " + utils::to_string(fd)
                 + ", do nothing");
         return;
@@ -301,12 +301,12 @@ void ConnectionHandler::_send_error(int fd)
         }
         else if (bytes_sent == 0) {
             close_connection(fd,
-                             weblog::WARNING,
+                             weblog::DEBUG,
                              "Write 0 bytes, client closing connection");
         }
         else {
             close_connection(fd,
-                             weblog::WARNING,
+                             weblog::DEBUG,
                              "Close the connection after handled error on fd: "
                                  + utils::to_string(fd));
         }

--- a/source/kernel/Reactor.cpp
+++ b/source/kernel/Reactor.cpp
@@ -3,14 +3,18 @@
 #include "ConnectionHandler.hpp"
 #include "HttpException.hpp"
 #include "Logger.hpp"
+#include "OperationInterrupt.hpp"
 #include "defines.hpp"
 #include "kernelUtils.hpp"
 #include "utils.hpp"
 #include <cerrno>
 #include <cstdio>
 #include <exception>
+#include <stdexcept>
 #include <unistd.h>
 #include <vector>
+#include <iostream>
+#include "OperationInterrupt.hpp"
 
 namespace webkernel
 {
@@ -169,7 +173,9 @@ void Reactor::_check_interrupt(void) const
 {
     if (stop_flag) {
         LOG(weblog::INFO, "Reactor received interrupt signal");
-        throw InterruptException();
+        // throw InterruptException();
+        std::cout << STY_GRE "\nShutdown webserver" STY_RES << std::endl;
+        throw OperationInterrupt(UNPRIMED);
     }
 }
 

--- a/source/kernel/Reactor.cpp
+++ b/source/kernel/Reactor.cpp
@@ -213,10 +213,10 @@ void Reactor::_handle_events(struct epoll_event* events, int nfds)
             for (std::map<int, IHandler*>::iterator it = _handlers.begin();
                  it != _handlers.end();
                  it++) {
-                LOG(weblog::WARNING,
+                LOG(weblog::DEBUG,
                     "activated fd: " + utils::to_string(it->first));
             }
-            LOG(weblog::WARNING,
+            LOG(weblog::DEBUG,
                 "using fd: " + utils::to_string(fd)
                     + " on handler: " + utils::to_string(_handlers[fd]));
             _handlers[fd]->handle_event(fd, events[i].events);

--- a/source/kernel/RequestProcessor.cpp
+++ b/source/kernel/RequestProcessor.cpp
@@ -48,7 +48,7 @@ bool RequestProcessor::analyze(int fd, std::string& buffer)
         _analyzer_pool[fd] = webshell::RequestAnalyzer(&buffer);
         reset_state(fd);
     }
-    LOG(weblog::WARNING, "read buffer: " + buffer);
+    LOG(weblog::DEBUG, "read buffer: " + buffer);
     while (i < buffer.size()) {
         _analyzer_pool[fd].feed(buffer[i]);
         if (_analyzer_pool[fd].is_complete()) {
@@ -196,7 +196,7 @@ void RequestProcessor::_handle_keep_alive(int fd)
 
 void RequestProcessor::_end_request(int fd)
 {
-    LOG(weblog::INFO, "End request on fd: " + utils::to_string(fd));
+    LOG(weblog::DEBUG, "End request on fd: " + utils::to_string(fd));
     remove_analyzer(fd);
     // reset_state(fd);
     _handle_keep_alive(fd);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,6 +14,7 @@
 #include "ExecuteWithUnwind.hpp"
 #include "Kernel.hpp"
 #include "Logger.hpp"
+#include "OperationInterrupt.hpp"
 #include "ReturnWithUnwind.hpp"
 #include "defines.hpp"
 #include <csignal>
@@ -72,6 +73,11 @@ int main(int argc, char** argv)
         config->destroy();
         weblog::Logger::destroy();
         return (e.status());
+    }
+    catch (const OperationInterrupt& e) {
+        config->destroy();
+        weblog::Logger::destroy();
+        return (SUCCESS);
     }
     catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/29 22:49:41 by lyeh              #+#    #+#             */
-/*   Updated: 2025/03/19 14:59:22 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/19 16:33:03 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
         config = webconfig::Config::instance();
         signal(SIGINT, handle_terminate_signal);
         weblog::Logger* logger = weblog::Logger::instance();
-        logger->set_level(weblog::CRITICAL);
+        logger->set_level(weblog::INFO);
         // weblog::logger->set_file_mode("webserver.log");
 
         config->print_config();

--- a/source/shell/HeaderAnalyzer.cpp
+++ b/source/shell/HeaderAnalyzer.cpp
@@ -6,7 +6,7 @@
 /*   By: mhuszar <mhuszar@student.42vienna.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/17 18:50:44 by mhuszar           #+#    #+#             */
-/*   Updated: 2025/03/19 15:25:09 by mhuszar          ###   ########.fr       */
+/*   Updated: 2025/03/19 20:23:28 by mhuszar          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -215,9 +215,6 @@ recipient MUST treat it as an unrecoverable error.  If this is a
 request message, the server MUST respond with a 400 (Bad Request)
 status code and then close the connection (RFC 7230 3.3.3).
 */
-
-// TODO: this check fails if they provide multiple Content-Length fields
-// first and *then* a transfer-encoding
 
 void HeaderAnalyzer::_field_end_crlf(unsigned char c)
 {

--- a/source/shell/Response.cpp
+++ b/source/shell/Response.cpp
@@ -51,7 +51,7 @@ void Response::set_status_code(StatusCode status_code)
 void Response::set_headers(std::map<std::string, std::string> headers)
 {
     if (_headers.size() > 0) {
-        LOG(weblog::WARNING, "Overwrite headers");
+        LOG(weblog::DEBUG, "Overwrite headers");
     }
     _headers = headers;
 }
@@ -91,7 +91,7 @@ std::string Response::serialize() const
     std::map<std::string, std::string>::const_iterator it;
 
     if (_status_code == UNDEFINED) {
-        LOG(weblog::WARNING, "Response status code is not set");
+        LOG(weblog::DEBUG, "Response status code is not set");
         return ("");
     }
     if (_status_code != IGNORE) {


### PR DESCRIPTION
This had a function defined in the header file, which is technically forbidden
Now we use `OperationInterrupt` instead